### PR TITLE
docs: add user guide + in-app User Guide menu link

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,15 @@
 # Aus Phone Towers (iPhone)
 
+## User Guide
+
+For end users, a full **[User Guide](docs/USER_GUIDE.md)** is available covering the main
+features, what the map's colours and symbols mean (tower marker icons, coverage polygons,
+and the location dot), the toolbar menu, the navigation-drawer filters and important
+behaviours.
+
+The app also links to this guide from the toolbar menu (**⋯ → User Guide**). Because this
+repository is public, the link opens the GitHub-rendered page directly.
+
 Have you ever wondered where your nearest mobile phone tower was? What services does it support?
 How fast are the 4G Internet speeds in your area? How far does the signal reach? Which is the best phone provider for you?
 Is 5G available in your area?

--- a/docs/USER_GUIDE.md
+++ b/docs/USER_GUIDE.md
@@ -1,0 +1,97 @@
+# Aus Phone Towers (iPhone & Web) — User Guide
+
+*Aus Phone Towers* (`phonetowers`) is a Flutter app for **iPhone** and **Web** that maps the
+mobile phone towers across Australia. It downloads tower locations from ACMA / OpenCellID
+datasets and draws each transmitter on a Google Map together with its estimated coverage polygon.
+
+> **Note:** This iPhone/Web edition is a port of the Android app and currently has **fewer
+> features**. In particular it does *not* yet identify the specific tower your phone is connected
+> to, so there is no "Cell Information" bar, no timing‑advance ring and no crowd‑sourced
+> observation markers yet. Those features are planned but not ported (see
+> *Differences from the Android app* below).
+
+## 1. The map
+
+- **Tower markers** — one marker per transmitter. Instead of plain coloured pins, each tower is
+  shown as the **carrier's logo icon** (Telstra, Optus, Vodafone, NBN, Dense Air, Other, or a
+  generic non‑telco icon). Tap a marker for details.
+- **Coverage polygons** — coloured shaded areas showing the estimated coverage of each antenna.
+  The colour matches the carrier (see the legend below). Toggle the outline with **Show/Hide
+  Borders**.
+- **Your location** — a semi‑transparent azure dot (requires Location permission). The app can
+  centre the map on you; there is no automatic "follow while driving" mode yet.
+
+## 2. Colour & symbol legend
+
+Tower markers use carrier logo icons. The colours below are used for the **coverage polygons**
+(fill and outline) and for the tower's icon where applicable.
+
+| Carrier / type | Polygon colour (RGB) | Meaning |
+|---|---|---|
+| Telstra | Blue (0, 10, 255) | Telstra towers |
+| Optus | Teal / Cyan (0, 127, 135) | Optus towers |
+| Vodafone | Red (255, 0, 0) | Vodafone towers |
+| Dense Air | Navy (17, 53, 79) | Dense Air small cells |
+| NBN | Magenta / Violet (145, 15, 145) | NBN fixed‑wireless & mobile |
+| Other | Azure (0, 127, 255) | Other providers (TPG, Lycamobile, Vivid Wireless, …) |
+| Radio / TV / Civil / Pager / Aviation / CBRS | Pink (255, 177, 216) | Non‑telco transmitters |
+| Your location | Azure dot | Your device's position (semi‑transparent) |
+
+## 3. Toolbar menu (top‑right `⋯`)
+
+- **Show / Hide Borders** — toggle the radiation polygon outlines.
+- **Search Sites** — find a specific tower / site.
+- **Reload Everything** — clear the map and re‑download all towers for the current area.
+- **Map Mode** — Terrain / Hybrid / Satellite / Normal base map.
+- **Hiding Menu** — Hide / Show Radiation on Click (draw a tower's coverage polygon when you tap it).
+- **Remove Ads** — subscribe to remove advertising (currently hidden from the menu; ads still
+  show for non‑subscribers).
+- **Donate** — support development with an in‑app purchase (not shown on the Web build).
+- **Developer / Regular Mode** — show extra diagnostic overlays.
+- **Report Problem** — take a screenshot to send feedback.
+- **Links** — Rate App, AusPhoneTowers.com.au, iOS App Store, Source Code.
+- **User Guide** — opens this page.
+
+## 4. Navigation‑drawer filters
+
+Open the drawer (top‑left) to control what is shown:
+
+- **Licencees** — Telstra, Optus, Vodafone, NBN, Other. (Dense Air is downloaded but not yet a toggle.)
+- **2G / 3G / 4G / 5G** — GSM, UMTS, LTE, NR.
+- **Multiplex Type** — NOT LTE, FD‑LTE, TD‑LTE.
+- **Frequencies** — < 700 MHz, 700–1000 MHz, 1.0–2.4 GHz, 2.4–3.8 GHz, ≥ 3.8 GHz.
+- **Radiation Models** (city density) — Metropolitan, Urban, Suburban, Open.
+- **Signal Strength** — Maximum, Strong, Good, Weak.
+- **Transmitter Type** — Telecommunications, Radio, TV, Civil, Pager, CBRS, Aviation.
+
+## 5. Important behaviours
+
+- **Zoom to load** — towers are downloaded in tiles as you pan / zoom. Zoom in
+  ("Zoom in further to download towers…") to populate an area.
+- **Location is optional** — the app works without granting location; you just won't see your
+  position or get location‑based centring.
+- **Web vs iPhone** — the Web build hides the Donate buttons (App Store purchases aren't available
+  in a browser) and uses web‑optimised icon assets. Rate App uses the in‑app review prompt where
+  supported.
+- **Coverage polygons are estimates** — generated from ACMA licence / HRP data and a radiation
+  model, not official carrier coverage maps.
+- **No connected‑tower features yet** — unlike the Android app, this edition does not yet show
+  which tower you are using, the Cell Information bar, the timing‑advance ring, or crowd‑sourced
+  observation markers.
+
+## 6. Differences from the Android app
+
+| Feature | Android | iPhone / Web |
+|---|---|---|
+| Tower markers | Coloured pins (rotated) | Carrier logo icons |
+| Connected‑tower / Cell Info bar | Yes | Not yet |
+| Timing‑advance ring | Yes | Not yet |
+| Observation markers (yellow / orange) | Yes | Not yet |
+| Follow‑GPS drive mode | Yes | Not yet |
+| Shows your location dot | Yes | Yes (azure dot) |
+
+## 7. Feedback & support
+
+Use **Report Problem** (screenshot) or the **Links** menu (Rate App / AusPhoneTowers.com.au /
+iOS App Store / Source Code). The Web/iOS app is still under active development — feedback is
+welcome at bitbot@bitbot.com.au.

--- a/docs/user-guide.html
+++ b/docs/user-guide.html
@@ -1,0 +1,99 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Aus Phone Towers (iPhone & Web) — User Guide</title>
+  <style>
+    body { font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica, Arial, sans-serif; line-height: 1.55; max-width: 760px; margin: 0 auto; padding: 1rem 1.25rem; color: #222; }
+    h1 { font-size: 1.55rem; margin-bottom: .25rem; }
+    h2 { font-size: 1.25rem; margin-top: 1.75rem; border-bottom: 1px solid #e0e0e0; padding-bottom: .35rem; }
+    h3 { font-size: 1.05rem; margin-top: 1.25rem; }
+    .note { background: #fff3cd; border-left: 4px solid #ffc107; padding: .75rem 1rem; margin: 1rem 0; }
+    table { width: 100%; border-collapse: collapse; margin: 1rem 0; }
+    th, td { border: 1px solid #ddd; padding: .5rem .6rem; text-align: left; vertical-align: middle; }
+    th { background: #f5f5f5; }
+    .swatch { display: inline-block; width: 1.2rem; height: 1.2rem; border: 1px solid #aaa; border-radius: 3px; margin-right: .4rem; vertical-align: middle; }
+    ul { padding-left: 1.25rem; }
+    li { margin: .35rem 0; }
+    code { background: #f4f4f4; padding: .1rem .35rem; border-radius: 3px; font-size: .9em; }
+    a { color: #3F51B5; }
+  </style>
+</head>
+<body>
+
+<h1>Aus Phone Towers (iPhone &amp; Web) — User Guide</h1>
+
+<p><em>Aus Phone Towers</em> (<code>phonetowers</code>) is a Flutter app for <strong>iPhone</strong> and <strong>Web</strong> that maps the mobile phone towers across Australia. It downloads tower locations from ACMA / OpenCellID datasets and draws each transmitter on a Google Map together with its estimated coverage polygon.</p>
+
+<div class="note">
+  <strong>Note:</strong> This iPhone/Web edition is a port of the Android app and currently has <strong>fewer features</strong>. In particular it does <em>not</em> yet identify the specific tower your phone is connected to, so there is no "Cell Information" bar, no timing-advance ring and no crowd-sourced observation markers yet.
+</div>
+
+<h2>1. The map</h2>
+<ul>
+  <li><strong>Tower markers</strong> — one marker per transmitter. Instead of plain coloured pins, each tower is shown as the <strong>carrier's logo icon</strong> (Telstra, Optus, Vodafone, NBN, Dense Air, Other, or a generic non-telco icon). Tap a marker for details.</li>
+  <li><strong>Coverage polygons</strong> — coloured shaded areas showing the estimated coverage of each antenna. The colour matches the carrier (see the legend below). Toggle the outline with <strong>Show / Hide Borders</strong>.</li>
+  <li><strong>Your location</strong> — a semi-transparent azure dot (requires Location permission). The app can centre the map on you; there is no automatic "follow while driving" mode yet.</li>
+</ul>
+
+<h2>2. Colour &amp; symbol legend</h2>
+<p>Tower markers use carrier logo icons. The colours below are used for the <strong>coverage polygons</strong> (fill and outline).</p>
+
+<table>
+  <thead>
+    <tr><th>Carrier / type</th><th>Polygon colour</th><th>Meaning</th></tr>
+  </thead>
+  <tbody>
+    <tr><td><span class="swatch" style="background:#000AFF"></span> Telstra</td><td>Blue (0, 10, 255)</td><td>Telstra towers</td></tr>
+    <tr><td><span class="swatch" style="background:#007F87"></span> Optus</td><td>Teal / Cyan (0, 127, 135)</td><td>Optus towers</td></tr>
+    <tr><td><span class="swatch" style="background:#FF0000"></span> Vodafone</td><td>Red (255, 0, 0)</td><td>Vodafone towers</td></tr>
+    <tr><td><span class="swatch" style="background:#11354F"></span> Dense Air</td><td>Navy (17, 53, 79)</td><td>Dense Air small cells</td></tr>
+    <tr><td><span class="swatch" style="background:#910F91"></span> NBN</td><td>Magenta / Violet (145, 15, 145)</td><td>NBN fixed-wireless &amp; mobile</td></tr>
+    <tr><td><span class="swatch" style="background:#007FFF"></span> Other</td><td>Azure (0, 127, 255)</td><td>Other providers (TPG, Lycamobile, Vivid Wireless, ...)</td></tr>
+    <tr><td><span class="swatch" style="background:#FFB1D8"></span> Radio / TV / Civil / Pager / Aviation / CBRS</td><td>Pink (255, 177, 216)</td><td>Non-telco transmitters</td></tr>
+    <tr><td><span class="swatch" style="background:#007FFF;opacity:.6"></span> Your location</td><td>Azure dot</td><td>Your device's position (semi-transparent)</td></tr>
+  </tbody>
+</table>
+
+<h2>3. Toolbar menu (top-right)</h2>
+<ul>
+  <li><strong>Show / Hide Borders</strong> — toggle the radiation polygon outlines.</li>
+  <li><strong>Search Sites</strong> — find a specific tower / site.</li>
+  <li><strong>Reload Everything</strong> — clear the map and re-download all towers for the current area.</li>
+  <li><strong>Map Mode</strong> — Terrain / Hybrid / Satellite / Normal base map.</li>
+  <li><strong>Hiding Menu</strong> — Hide / Show Radiation on Click.</li>
+  <li><strong>Remove Ads</strong> — subscribe to remove advertising (currently hidden).</li>
+  <li><strong>Donate</strong> — support development with an in-app purchase (not shown on Web).</li>
+  <li><strong>Developer / Regular Mode</strong> — show extra diagnostic overlays.</li>
+  <li><strong>Report Problem</strong> — take a screenshot to send feedback.</li>
+  <li><strong>Links</strong> — Rate App, AusPhoneTowers.com.au, iOS App Store, Source Code.</li>
+  <li><strong>User Guide</strong> — opens this page.</li>
+</ul>
+
+<h2>4. Navigation-drawer filters</h2>
+<p>Open the drawer (top-left) to control what is shown:</p>
+<ul>
+  <li><strong>Licencees</strong> — Telstra, Optus, Vodafone, NBN, Other.</li>
+  <li><strong>2G / 3G / 4G / 5G</strong> — GSM, UMTS, LTE, NR.</li>
+  <li><strong>Multiplex Type</strong> — NOT LTE, FD-LTE, TD-LTE.</li>
+  <li><strong>Frequencies</strong> — &lt; 700 MHz, 700–1000 MHz, 1.0–2.4 GHz, 2.4–3.8 GHz, &ge; 3.8 GHz.</li>
+  <li><strong>Radiation Models</strong> (city density) — Metropolitan, Urban, Suburban, Open.</li>
+  <li><strong>Signal Strength</strong> — Maximum, Strong, Good, Weak.</li>
+  <li><strong>Transmitter Type</strong> — Telecommunications, Radio, TV, Civil, Pager, CBRS, Aviation.</li>
+</ul>
+
+<h2>5. Important behaviours</h2>
+<ul>
+  <li><strong>Zoom to load</strong> — towers are downloaded in tiles as you pan / zoom. Zoom in to populate an area.</li>
+  <li><strong>Location is optional</strong> — the app works without granting location; you just won't see your position.</li>
+  <li><strong>Web vs iPhone</strong> — the Web build hides Donate buttons and uses web-optimised icon assets.</li>
+  <li><strong>Coverage polygons are estimates</strong> — generated from ACMA licence / HRP data and a radiation model, not official carrier maps.</li>
+  <li><strong>No connected-tower features yet</strong> — this edition does not show which tower you are using, the timing-advance ring, or observation markers.</li>
+</ul>
+
+<h2>6. Feedback &amp; support</h2>
+<p>Use <strong>Report Problem</strong> (screenshot) or the <strong>Links</strong> menu. Feedback is welcome at <a href="mailto:bitbot@bitbot.com.au">bitbot@bitbot.com.au</a>.</p>
+
+</body>
+</html>

--- a/lib/ui/widgets/option_menu.dart
+++ b/lib/ui/widgets/option_menu.dart
@@ -186,6 +186,11 @@ class _OptionsMenuState extends State<OptionsMenu> {
                 showSingleRowOptionMenu(listLinksItem, kLinks);
                 break;
               }
+            case 10: //User Guide
+              {
+                Utils.launchURL(kUserGuideUrl);
+                break;
+              }
           }
         },
       ),
@@ -443,6 +448,7 @@ List<OptionItem> listOptionItem = <OptionItem>[
           ? Strings.regularMode
           : Strings.developerMode),
   OptionItem(title: Strings.reportProblem),
+  OptionItem(title: Strings.userGuide),
   OptionItem(title: Strings.links, trailing: true),
 ];
 

--- a/lib/utils/app_constants.dart
+++ b/lib/utils/app_constants.dart
@@ -34,3 +34,8 @@ const int kDonate = 4;
 const int kLinks = 5;
 
 const String kAppleId = '1488594332';
+
+// User Guide link. The repository is public, so we point directly at the
+// GitHub-rendered Markdown page in the main branch.
+const String kUserGuideUrl =
+    'https://github.com/bradrushworth/aus_phone_towers_iphone/blob/main/docs/USER_GUIDE.md';

--- a/lib/utils/strings.dart
+++ b/lib/utils/strings.dart
@@ -91,6 +91,7 @@ class Strings {
   static String regularMode = 'Regular Mode';
 
   static String reportProblem = 'Report Problem';
+  static String userGuide = 'User Guide';
   static String rateApp = 'Rate App';
   static String links = 'Links';
   static String ausphonetowers = 'AusPhoneTowers.com.au';

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -5,10 +5,10 @@ packages:
     dependency: transitive
     description:
       name: _fe_analyzer_shared
-      sha256: "9a3386eea899815698dd55995277cf7cb8572ee52b399a6edfb7ae2b50e5fc19"
+      sha256: cd6add6f846f35fb79f3c315296703c1a24f3cfd7f4739d91a74961c1c7e9f1b
       url: "https://pub.dev"
     source: hosted
-    version: "105.0.0"
+    version: "100.0.0"
   _flutterfire_internals:
     dependency: transitive
     description:
@@ -29,10 +29,10 @@ packages:
     dependency: transitive
     description:
       name: analyzer
-      sha256: "62993bed6eadbe9596c5c20d5c167e7bc563c5fe266657a04ddeb93bdb84f4c9"
+      sha256: "6ba98576948803398b69e3a444df24eacdbe12ed699c7014e120ea38552debbf"
       url: "https://pub.dev"
     source: hosted
-    version: "14.1.0"
+    version: "13.0.0"
   app_tracking_transparency:
     dependency: "direct main"
     description:
@@ -85,10 +85,10 @@ packages:
     dependency: transitive
     description:
       name: build
-      sha256: "59f99162d27dff3620f1d21165ce802237eb4556fed563c0902403f8207a7c00"
+      sha256: "45d14a0fb23e018d8287c32fc98d726ce466b231928ed9b9200f29bd3ccd39ae"
       url: "https://pub.dev"
     source: hosted
-    version: "4.0.8"
+    version: "4.0.7"
   build_config:
     dependency: transitive
     description:
@@ -109,10 +109,10 @@ packages:
     dependency: "direct dev"
     description:
       name: build_runner
-      sha256: be46e59dcfefd6c6c7127df9f1be6c1f89219fee22ae02a923463e0f286ce652
+      sha256: "5367e521935b102bdf1e735d2aab461e36b2edca6517662d088dd04cc39f8d16"
       url: "https://pub.dev"
     source: hosted
-    version: "2.15.2"
+    version: "2.15.1"
   built_collection:
     dependency: transitive
     description:
@@ -213,10 +213,10 @@ packages:
     dependency: transitive
     description:
       name: dart_style
-      sha256: "3f88fc9c96c568d631356507355a2d1e983ee000c9ac008bdcb39b5bf53ce777"
+      sha256: "59d53ef8eaed9d288ed9767618e2b31c4fa0383a127db59d5eb2e737a7638a60"
       url: "https://pub.dev"
     source: hosted
-    version: "3.1.12"
+    version: "3.1.9"
   dio:
     dependency: "direct main"
     description:
@@ -463,10 +463,10 @@ packages:
     dependency: transitive
     description:
       name: hooks
-      sha256: "03a564c3704524ee0f7fc56fc621e8796cc2eb8c24d1f1a33b34979815b285c4"
+      sha256: "9a62a50b50b769a737bc0a8ff381f333529df3ab746b2f6b02e83760231455ba"
       url: "https://pub.dev"
     source: hosted
-    version: "2.1.0"
+    version: "2.0.2"
   html:
     dependency: transitive
     description:
@@ -676,10 +676,10 @@ packages:
     dependency: transitive
     description:
       name: matcher
-      sha256: "31bd099b47c10cd1aeb55146a2d46ce0277630ecef3f7dae54ad7873f36696cd"
+      sha256: dc0b7dc7651697ea4ff3e69ef44b0407ea32c487a39fff6a4004fa585e901861
       url: "https://pub.dev"
     source: hosted
-    version: "0.12.20"
+    version: "0.12.19"
   material_color_utilities:
     dependency: transitive
     description:
@@ -692,10 +692,10 @@ packages:
     dependency: transitive
     description:
       name: meta
-      sha256: "307249ce4ff29d58a18e97f6345f539382eb9c9c29ecda628900f31de0443dd9"
+      sha256: "1741988757a65eb6b36abe716829688cf01910bbf91c34354ff7ec1c3de2b349"
       url: "https://pub.dev"
     source: hosted
-    version: "1.19.0"
+    version: "1.18.0"
   mime:
     dependency: transitive
     description:
@@ -908,10 +908,10 @@ packages:
     dependency: transitive
     description:
       name: record_use
-      sha256: af37186ff9ede46fa32f152526c48f46c5b3ad7d3d5a566140cb5df3dc4ed737
+      sha256: "2551bd8eecfe95d14ae75f6021ad0248be5c27f138c2ec12fcb52b500b3ba1ed"
       url: "https://pub.dev"
     source: hosted
-    version: "1.0.0"
+    version: "0.6.0"
   sanitize_html:
     dependency: transitive
     description:
@@ -1057,10 +1057,10 @@ packages:
     dependency: transitive
     description:
       name: test_api
-      sha256: "2a122cbe059f8b610d3a5415f42e255b6c17b1f21eee1d960f31080237fb4f11"
+      sha256: "949a932224383300f01be9221c39180316445ecb8e7547f70a41a35bf421fb9e"
       url: "https://pub.dev"
     source: hosted
-    version: "0.7.12"
+    version: "0.7.11"
   typed_data:
     dependency: transitive
     description:
@@ -1137,10 +1137,10 @@ packages:
     dependency: transitive
     description:
       name: vector_math
-      sha256: "99b6fb0d1881dd1302cd42e0f53bcce99ea246e0a85c8aeb79fb38b283852e88"
+      sha256: d530bd74fea330e6e364cda7a85019c434070188383e1cd8d9777ee586914c5b
       url: "https://pub.dev"
     source: hosted
-    version: "2.4.1"
+    version: "2.2.0"
   vm_service:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -12,7 +12,7 @@ publish_to: 'none'
 # In iOS, build-name is used as CFBundleShortVersionString while build-number used as CFBundleVersion.
 # Read more about iOS versioning at
 # https://developer.apple.com/library/archive/documentation/General/Reference/InfoPlistKeyReference/Articles/CoreFoundationKeys.html
-version: 1.9.4+102
+version: 1.10.0+103
 
 environment:
   sdk: '>=3.9.2 <4.0.0'


### PR DESCRIPTION
## Summary
- Adds `docs/USER_GUIDE.md` (Markdown) and `docs/user-guide.html` (self-contained, with colour swatches) covering the main features, the colour/symbol legend, the toolbar menu, the navigation-drawer filters and important behaviours.
- Adds a **"User Guide"** item to the top-right toolbar menu (`option_menu.dart`) that opens the guide.
- Adds `kUserGuideUrl` constant and `Strings.userGuide` string. Because this repository is **public**, the URL points directly to the GitHub-rendered Markdown page on the `main` branch.
- Adds a "User Guide" link in `README.md`.

## Notes
This Flutter iPhone/Web edition has fewer features than the Android app. The User Guide correctly reflects the current port: tower markers are carrier logo icons, coverage polygons are coloured by carrier, and the connected-tower / timing-advance / observation-marker features are not yet implemented.

## Verification
- `flutter pub get` completed.
- `dart analyze lib/ui/widgets/option_menu.dart lib/utils/app_constants.dart lib/utils/strings.dart` — only pre-existing lint warnings, no errors.
