### PR TITLE
Release 1.11.5+110: Port path loss algorithm from Java app

### DIFF
--- a/.clinerules
+++ b/.clinerules
@@ -1,7 +1,12 @@
 # Project Rules — aus_phone_towers_iphone (iOS)
 
+> **This file is kept for backwards compatibility.** The canonical agent instructions now live in
+> **`AGENTS.md`** at the project root. That file is recognised by all AI coding agents (Cline,
+> Claude Code, OpenHands, Cursor, etc.). If you make changes, update `AGENTS.md` and keep this
+> file as a pointer.
+
 These rules apply ONLY to this iPhone/iOS repository. The Android project
-(`aus_phone_towers`) has its own separate `.clinerules` and should not share these.
+(`aus_phone_towers_java`) has its own `AGENTS.md` and should not share these.
 
 ## Documentation must be kept in sync
 Whenever you add, change, or remove a user-facing feature, command, or behaviour in this

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,121 @@
+# AGENTS.md — Australian Phone Towers (aus_phone_towers_iphone)
+
+Guidance for any AI agent or developer working in this repository. These rules apply ONLY to this
+iPhone/Flutter repository. The Android project (`aus_phone_towers_java`) has its own `AGENTS.md`
+and should not share these.
+
+## Project basics
+- Flutter app (Dart), targeting iOS (primary) and Android (secondary). Package: `phonetowers`.
+- State management: raw `StatefulWidget` / `setState` (no Riverpod/Bloc/etc.).
+- Networking: `dio` for HTTP, REST API at `https://api.bitbot.com.au/api`.
+- Maps: `google_maps_flutter`.
+- Logging: `logger` package.
+- Dependencies in `pubspec.yaml`. Run `flutter pub get` after pulling.
+
+## Build commands
+- Install dependencies: `flutter pub get`
+- Run app: `flutter run`
+- Run unit tests: `flutter test`
+- Run a specific test: `flutter test test/pathloss/`
+- Static analysis: `flutter analyze`
+- Build iOS: `flutter build ios`
+- Build Android APK: `flutter build apk`
+- Clean: `flutter clean`
+- Integration tests: `flutter drive --driver=test_driver/integration_test.dart --target=integration_test/better_test.dart`
+
+## Flutter SDK
+- Flutter SDK is installed at `/home/openhands/tools/flutter` (stable channel).
+- Dart SDK is bundled inside Flutter at `/home/openhands/tools/flutter/bin/cache/dart-sdk`.
+- If binary permissions are missing after extraction, run:
+  `chmod +x /home/openhands/tools/flutter/bin/cache/dart-sdk/bin/dart*` and
+  `find /home/openhands/tools/flutter/bin/cache/artifacts -type f -name "impellerc" -o -name "font_subset" -o -name "gen_snapshot" | xargs chmod +x`
+
+## Path loss module (lib/pathloss/)
+The path loss algorithm estimates the distance a radio signal travels given a measured path-loss in
+dB. It is ported from the Java Android app's `au.com.bitbot.phonetowers.pathloss` package.
+
+### Architecture
+- **`PathLossModel`** (interface): `calculateDistance(density, levelInDb, freqInMHz, height)` and
+  `calculateDistanceWithContext(mnc, networkType, density, levelInDb, freqInMHz, height)`.
+- **`AnalyticPathLossModel`**: Okumura-Hata / COST-231-Hata closed-form formulas. The fallback when
+  no trained coefficients are available. Exposes `hataInterceptDb` / `hataSlopeDb` for the
+  Hata-anchored trained forms.
+- **`Nr3gppPathLossModel`**: 3GPP TR 38.901 (5G NR) path-loss anchor. Used as the calibration anchor
+  for 5G NR observations and as the runtime model when no learned NR coefficients exist.
+- **`LearnedPathLossModel`**: Uses trained coefficients (fetched from REST). Three functional forms:
+  - `log-distance` (legacy): `level = b0 + b1·log10(d) + b2·log10(f) + b3·log10(h)`
+  - `hata-correction`: `level = hataIntercept + b0 + b1·hataSlope·log10(d)`
+  - `hata-calibration` (current): `log10(d) = b0 + b1·log10(hataDistance)`
+  Falls back to analytic Hata (or 3GPP 38.901 for NR) when no coefficients are trained.
+- **`PathLossCoefficients`**: Container for trained coefficients, keyed by density-only or composite
+  (mnc|networkType|band|density) keys. JSON serialisable (`toJson` / `fromJson`).
+- **`PathLossKey`**: Builds composite lookup keys and band buckets (LOW/MID/HIGH).
+- **`PathLossModelProvider`**: Singleton. On app startup, fetches coefficients from the REST API
+  (`/api/towers/pathloss_coefficients/`). Until the fetch completes (or if it fails), falls back to
+  the analytic model. The provider is the single entry point used by `GetLicenceHRP` and
+  `PolygonHelper`.
+- **`LinearRegression`**: OLS solver (used by tests; the actual training happens server-side in the
+  Java app).
+
+### REST endpoint
+- Coefficients are fetched from `https://api.bitbot.com.au/api/towers/pathloss_coefficients/?_view=json&_expand=no&_count=100`
+- The Java Android app trains the coefficients and writes them to the MySQL `pathloss_coefficients`
+  table. This iPhone app only reads them — it does not train.
+- REST client: `lib/restful/get_path_loss_coefficients.dart`
+
+### Wiring
+- `lib/restful/get_licenceHRP.dart`: `calculateDistance` delegates to `PathLossModelProvider`.
+  The context-aware overload `calculateDistanceWithContext` uses composite (mnc+networkType+density)
+  lookup, matching the Android app's tower-mapping path.
+- `lib/helpers/polygon_helper.dart`: `createBasicPolygon` uses the composite context lookup so
+  estimated polygons use the same trained coefficients as the mapping path.
+- `lib/main.dart`: `PathLossModelProvider` is initialised fire-and-forget after secrets are loaded.
+
+### Tests
+Tests are in `test/pathloss/` and are ported from the Java app's test suite:
+- `analytic_path_loss_model_test.dart`: pins exact Hata formula numeric outputs.
+- `nr3gpp_path_loss_model_test.dart`: 3GPP 38.901 model behaviour (finite distances, monotonicity,
+  b0=0/b1=1 reproduces anchor, NR fallback).
+- `learned_path_loss_model_test.dart`: fallback to analytic, coefficient inversion, Hata-anchored
+  forms, JSON round-trip, composite overload gap fix.
+- `linear_regression_test.dart`: OLS solver correctness (exact fit, noisy fit, singular matrix).
+
+Run with: `flutter test test/pathloss/`
+
+## Documentation must be kept in sync
+Whenever you add, change, or remove a user-facing feature, command, or behaviour in this
+project, you MUST also update the relevant documentation before considering the task complete:
+
+- `docs/USER_GUIDE.md` — the end-user guide (toolbar menu, map features, behaviours, legends).
+- `README.md` — the developer/feature overview, including the Android-vs-iOS feature-comparison
+  table and the signal-propagation notes.
+
+This applies to new menu items, exported formats, map overlays/labels, settings, and any
+behaviour change a user would notice. Do not leave docs stale after a code change.
+
+## Push to `main` only for an explicit release
+A Codemagic build is triggered by every push, and each build costs money, so:
+
+- **Do NOT push to `main` for ordinary / non-release commits.** Keep that work on a branch
+  (or simply don't push) so a build is not started on every commit.
+- You **may** push directly to `main` only when the user explicitly asks for a release of a
+  new version of the app. An explicit release always includes a version bump (see
+  "Only bump version when releasing" below), which is what signals a real release.
+- When releasing, bump the version and push to `main`. A separate release branch is not
+  required unless the user asks for one.
+- If the user asks for a normal commit / branch push (not a release), push the branch only —
+  do not push to `main`.
+
+## Only bump version when releasing
+The iOS app version lives in `pubspec.yaml` (`version:` — `x.y.z+build`). Bump it as part of
+a release. Pure doc-only or non-release commits do not require a version bump and may be
+pushed from a non-main branch normally.
+
+## Conventions
+- Dart style: follow `flutter_lints` (enforced by `flutter analyze`). Fix all warnings before
+  committing.
+- File naming: `lowercase_with_underscores.dart` for source files.
+- Test files: `test/` directory mirroring `lib/` structure, `_test.dart` suffix.
+- Prefer targeted edits to existing files over creating new files with different suffixes.
+- The `log10` function is a top-level function in `lib/helpers/translate_frequencies.dart`, NOT
+  `dart:math`. Import it where needed (the path loss module and tests use it extensively).

--- a/README.md
+++ b/README.md
@@ -89,6 +89,32 @@ The coverage-polygon math was checked against the Android implementation and is 
   on iOS using a small centroid marker per polygon. They are a cosmetic aid only and do not affect
   the propagation calculation.
 
+### Path loss algorithm (learned coefficients)
+
+The path-loss model has been ported from the Java Android app to this Flutter app. The algorithm
+estimates the distance a radio signal travels given a measured path-loss in dB, using learned
+coefficients fetched from the REST API at
+`https://api.bitbot.com.au/api/towers/pathloss_coefficients/`.
+
+**How it works:**
+
+1. On app startup, `PathLossModelProvider` fetches trained coefficients from the REST API (the
+   Java Android app trains these server-side from crowd-sourced signal observations and writes
+   them to the MySQL `pathloss_coefficients` table).
+2. The learned model (`LearnedPathLossModel`) uses one of three functional forms:
+   - **log-distance** (legacy): `level = b0 + b1·log10(d) + b2·log10(f) + b3·log10(h)`
+   - **hata-correction**: `level = hataIntercept + b0 + b1·hataSlope·log10(d)`
+   - **hata-calibration** (current): `log10(d) = b0 + b1·log10(hataDistance)`
+3. Coefficients are looked up by composite key (telco MNC + network type + frequency band + city
+   density), falling back to density-only, then to the analytic Hata/COST-231 model if no trained
+   coefficients exist.
+4. For 5G NR, the 3GPP TR 38.901 model is used as the anchor instead of Hata.
+5. If the REST fetch fails or hasn't completed yet, the analytic model is used — the app behaves
+   exactly as before until training data is available.
+
+This means the iPhone app now draws the same polygon shapes and distances as the Android app,
+using the same trained coefficients. See `AGENTS.md` for full architecture details.
+
 Some relevant links:
 
 * [This repository](https://github.com/bradrushworth/aus_phone_towers_iphone)

--- a/lib/helpers/polygon_helper.dart
+++ b/lib/helpers/polygon_helper.dart
@@ -521,13 +521,20 @@ class PolygonHelper with ChangeNotifier {
         int receiver_dBm = polygons[p];
         double freeSpaceLoss_dBi = power_dBm - receiver_dBm;
 
+        // Use the composite (mnc + networkType + density + frequency-band) overload so the
+        // estimate is tuned to the SAME trained coefficients as the connected-tower path
+        // (learned from observed signal strengths), instead of only the density-only
+        // coefficients. The composite lookup degrades gracefully
+        // (composite -> density-only -> analytic Hata), identical to the mapping path.
         CityDensity model = (device.getRadiationModel() ??
             GetLicenceHRP.defaultRadiationModel) as CityDensity;
-        double distanceKm = GetLicenceHRP.calculateDistance(
+        double distanceKm = GetLicenceHRP.calculateDistanceWithContext(
+            TelcoHelper.getMnc(site.getTelco()),
+            device.getNetworkType(),
             model,
             freeSpaceLoss_dBi,
             freqInMHz.toDouble(),
-            towerHeight + hillHeight.toDouble());
+            (towerHeight + hillHeight).toDouble());
         //Log.d("PolygonHelper", "distanceKm="+distanceKm);
 
 //    TreeSet<HeightDistancePair> heightToDistance = site.getHeightsAlongBearing(distanceKm, bearing);//TODO later on

--- a/lib/helpers/polygon_helper.dart
+++ b/lib/helpers/polygon_helper.dart
@@ -526,8 +526,8 @@ class PolygonHelper with ChangeNotifier {
         // (learned from observed signal strengths), instead of only the density-only
         // coefficients. The composite lookup degrades gracefully
         // (composite -> density-only -> analytic Hata), identical to the mapping path.
-        CityDensity model = (device.getRadiationModel() ??
-            GetLicenceHRP.defaultRadiationModel) as CityDensity;
+        CityDensity model = device.getRadiationModel() ??
+            GetLicenceHRP.defaultRadiationModel;
         double distanceKm = GetLicenceHRP.calculateDistanceWithContext(
             TelcoHelper.getMnc(site.getTelco()),
             device.getNetworkType(),

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -37,8 +37,8 @@ Future<void> main() async {
 
     if (!kIsWeb && Platform.isIOS) {
       // Show tracking authorization dialog and ask for permission
-      final status = await AppTrackingTransparency.requestTrackingAuthorization();
-      final uuid = await AppTrackingTransparency.getAdvertisingIdentifier();
+      await AppTrackingTransparency.requestTrackingAuthorization();
+      await AppTrackingTransparency.getAdvertisingIdentifier();
     }
 
     // Initialize Firebase

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -13,6 +13,7 @@ import 'package:phonetowers/helpers/map_helper.dart';
 import 'package:phonetowers/helpers/purchase_helper.dart';
 import 'package:phonetowers/helpers/search_helper.dart';
 import 'package:phonetowers/helpers/site_helper.dart';
+import 'package:phonetowers/pathloss/path_loss_model_provider.dart';
 import 'package:phonetowers/ui/map_common.dart';
 import 'package:phonetowers/utils/secretloader.dart';
 import 'package:phonetowers/utils/strings.dart';
@@ -91,6 +92,11 @@ Future<void> main() async {
     AdsHelper.iOSLandscapeAdUnitId = secret.iOSLandscapeAdUnitId;
     PolygonHelper.terrainAwarenessKey = secret.terrainAwarenessKey;
     //print("iOSLandscapeAdUnitId is ${secret.iOSLandscapeAdUnitId}");
+
+    // Fetch learned path-loss coefficients from the server (fire-and-forget). The app
+    // continues with the analytic Hata/COST-231 fallback until the fetch completes, then
+    // the learned model is swapped in — matching the Android app's behaviour.
+    PathLossModelProvider.initProvider();
 
     /*
   * runZoned Provides monitoring on whole app and reporting to the FireBase.

--- a/lib/pathloss/analytic_path_loss_model.dart
+++ b/lib/pathloss/analytic_path_loss_model.dart
@@ -1,0 +1,102 @@
+import 'dart:math' as math;
+
+import 'package:phonetowers/helpers/network_type_helper.dart';
+import 'package:phonetowers/helpers/translate_frequencies.dart';
+import 'package:phonetowers/pathloss/path_loss_model.dart';
+import 'package:phonetowers/restful/get_licenceHRP.dart';
+
+/// The legacy Okumura-Hata / COST-231-Hata analytic path-loss model, extracted verbatim from
+/// the original inline [GetLicenceHRP.calculateDistance] so it can be kept as a reference
+/// implementation and as the per-density fallback used by [LearnedPathLossModel] until real-world
+/// coefficients are trained.
+///
+/// Ported from the Java `au.com.bitbot.phonetowers.pathloss.AnalyticPathLossModel`.
+class AnalyticPathLossModel implements PathLossModel {
+  /// Mobile station antenna height above local terrain [m] — matches the original constant.
+  static const double heightReceiverFromGround = 1;
+
+  @override
+  double calculateDistance(
+      CityDensity density, double levelInDb, double freqInMHz, double height) {
+    double hb = height;
+    double hm = heightReceiverFromGround;
+    double fc = freqInMHz;
+
+    double a = 69.55 + 26.16 * log10(fc) - 13.82 * log10(hb);
+    double b = 44.9 - 6.55 * log10(hb);
+
+    if (density == CityDensity.METRO) {
+      double e = (1.1 * log10(fc) - 0.7) * hm - (1.56 * log10(fc) - 0.8);
+      double f = 46.3 + 33.9 * log10(fc) - 13.82 * log10(hb);
+      double g = 3;
+      return math.pow(10, (levelInDb + e - f - g) / b).toDouble();
+    } else if (density == CityDensity.URBAN && freqInMHz >= 300) {
+      double e = 3.2 * math.pow(log10(11.7554 * hm), 2) - 4.97;
+      return math.pow(10, (levelInDb + e - a) / b).toDouble();
+    } else if (density == CityDensity.URBAN) {
+      double e = 8.29 * math.pow(log10(1.54 * hm), 2) - 1.1;
+      return math.pow(10, (levelInDb + e - a) / b).toDouble();
+    } else if (density == CityDensity.MEDIUM) {
+      double e = (1.1 * log10(fc) - 0.7) * hm - (1.56 * log10(fc) - 0.8);
+      return math.pow(10, (levelInDb + e - a) / b).toDouble();
+    } else if (density == CityDensity.SUBURBAN) {
+      double c = 2 * math.pow(log10(fc / 28), 2) + 5.4;
+      c -= 4.42;
+      return math.pow(10, (levelInDb + c - a) / b).toDouble();
+    } else if (density == CityDensity.OPEN) {
+      double d = 4.78 * math.pow(log10(fc), 2) - 18.33 * log10(fc) + 40.94;
+      d -= 4.42 * 2;
+      return math.pow(10, (levelInDb + d - a) / b).toDouble();
+    } else {
+      return 0;
+    }
+  }
+
+  /// The Hata/COST-231 path-loss intercept for this environment, i.e. the modelled path loss
+  /// (dB) at distance = 1 km. Exposing the anchor lets a trained model learn a small correction
+  /// to Hata instead of re-learning the whole frequency/height dependence from noisy data.
+  static double hataInterceptDb(
+      CityDensity density, double freqInMHz, double height) {
+    double hb = height;
+    double hm = heightReceiverFromGround;
+    double fc = freqInMHz;
+
+    double a = 69.55 + 26.16 * log10(fc) - 13.82 * log10(hb);
+
+    if (density == CityDensity.METRO) {
+      double e = (1.1 * log10(fc) - 0.7) * hm - (1.56 * log10(fc) - 0.8);
+      double f = 46.3 + 33.9 * log10(fc) - 13.82 * log10(hb);
+      double g = 3;
+      return f + g - e;
+    } else if (density == CityDensity.URBAN && freqInMHz >= 300) {
+      double e = 3.2 * math.pow(log10(11.7554 * hm), 2) - 4.97;
+      return a - e;
+    } else if (density == CityDensity.URBAN) {
+      double e = 8.29 * math.pow(log10(1.54 * hm), 2) - 1.1;
+      return a - e;
+    } else if (density == CityDensity.MEDIUM) {
+      double e = (1.1 * log10(fc) - 0.7) * hm - (1.56 * log10(fc) - 0.8);
+      return a - e;
+    } else if (density == CityDensity.SUBURBAN) {
+      double c = 2 * math.pow(log10(fc / 28), 2) + 5.4;
+      c -= 4.42;
+      return a - c;
+    } else if (density == CityDensity.OPEN) {
+      double d = 4.78 * math.pow(log10(fc), 2) - 18.33 * log10(fc) + 40.94;
+      d -= 4.42 * 2;
+      return a - d;
+    }
+    return double.nan;
+  }
+
+  /// The Hata distance slope B = 44.9 - 6.55·log10(height) (dB per decade of km).
+  static double hataSlopeDb(double height) {
+    return 44.9 - 6.55 * log10(height);
+  }
+
+  @override
+  double calculateDistanceWithContext(int mnc, NetworkType networkType,
+      CityDensity density, double levelInDb, double freqInMHz, double height) {
+    return calculateDistance(density, levelInDb, freqInMHz, height);
+  }
+}

--- a/lib/pathloss/learned_path_loss_model.dart
+++ b/lib/pathloss/learned_path_loss_model.dart
@@ -1,0 +1,140 @@
+import 'dart:math' as math;
+
+import 'package:phonetowers/helpers/network_type_helper.dart';
+import 'package:phonetowers/helpers/translate_frequencies.dart';
+import 'package:phonetowers/pathloss/analytic_path_loss_model.dart';
+import 'package:phonetowers/pathloss/nr3gpp_path_loss_model.dart';
+import 'package:phonetowers/pathloss/path_loss_coefficients.dart';
+import 'package:phonetowers/pathloss/path_loss_key.dart';
+import 'package:phonetowers/pathloss/path_loss_model.dart';
+import 'package:phonetowers/restful/get_licenceHRP.dart';
+
+/// Path-loss model whose constants are learned from real observations.
+///
+/// Two functional forms are supported, selected by [PathLossCoefficients.form]:
+/// - log-distance (legacy): levelInDb = b0 + b1·log10(d) + b2·log10(f) + b3·log10(h)
+/// - hata-correction: levelInDb = hataIntercept + b0 + b1·hataSlope·log10(d)
+/// - hata-calibration (current): log10(d) = b0 + b1·log10(hataDistance)
+///
+/// When the richer (mnc, networkType, density) context is supplied, it first looks up the
+/// composite group `density|mnc|networkType|band`; if that has no learned coefficients it falls
+/// back to the density-only group, and if neither exists it delegates to the analytic Hata/COST-231
+/// model (or the 3GPP 38.901 anchor for NR) so the app behaves exactly as before until training
+/// data is available. Any numerical failure also falls back.
+///
+/// Ported from the Java `au.com.bitbot.phonetowers.pathloss.LearnedPathLossModel`.
+class LearnedPathLossModel implements PathLossModel {
+  final PathLossCoefficients coefficients;
+  final PathLossModel fallback;
+  final Nr3gppPathLossModel _nrAnchor;
+
+  LearnedPathLossModel(this.coefficients, [PathLossModel? fallback])
+      : fallback = fallback ?? AnalyticPathLossModel(),
+        _nrAnchor = Nr3gppPathLossModel();
+
+  @override
+  double calculateDistance(
+      CityDensity density, double levelInDb, double freqInMHz, double height) {
+    List<double>? beta = coefficients.get(density);
+    if (beta == null) {
+      return fallback.calculateDistance(density, levelInDb, freqInMHz, height);
+    }
+    double distanceKm = _invert(beta, null, density, levelInDb, freqInMHz, height);
+    return _isUsable(distanceKm)
+        ? distanceKm
+        : fallback.calculateDistance(density, levelInDb, freqInMHz, height);
+  }
+
+  @override
+  double calculateDistanceWithContext(int mnc, NetworkType networkType,
+      CityDensity density, double levelInDb, double freqInMHz, double height) {
+    String band = PathLossKey.bandBucket(freqInMHz * 1_000_000.0);
+    List<double>? beta =
+        coefficients.getComposite(mnc, networkType, band, density);
+    if (beta == null) {
+      beta = coefficients.get(density);
+    }
+    if (beta == null) {
+      if (networkType == NetworkType.NR) {
+        double nr =
+            _nrAnchor.calculateDistance(density, levelInDb, freqInMHz, height);
+        return _isUsable(nr)
+            ? nr
+            : fallback.calculateDistance(density, levelInDb, freqInMHz, height);
+      }
+      return fallback.calculateDistance(density, levelInDb, freqInMHz, height);
+    }
+    double distanceKm =
+        _invert(beta, networkType, density, levelInDb, freqInMHz, height);
+    return _isUsable(distanceKm)
+        ? distanceKm
+        : fallback.calculateDistance(density, levelInDb, freqInMHz, height);
+  }
+
+  double _invert(List<double> beta, NetworkType? networkType, CityDensity density,
+      double levelInDb, double freqInMHz, double height) {
+    if (coefficients.isHataCalibrationForm) {
+      return _applyHataCalibration(
+          beta, networkType, density, levelInDb, freqInMHz, height);
+    }
+    if (coefficients.isHataCorrectionForm) {
+      return _invertHataCorrection(beta, density, levelInDb, freqInMHz, height);
+    }
+    return _invertLogDistance(beta, levelInDb, freqInMHz, height);
+  }
+
+  /// Hata calibration — the analytic model's own log-distance estimate is rescaled by
+  /// coefficients fit in the log-distance direction, so the result can never blow up.
+  /// For NR cells, the 3GPP TR 38.901 model is used as the anchor instead of Hata.
+  static double _applyHataCalibration(
+      List<double> beta,
+      NetworkType? networkType,
+      CityDensity density,
+      double levelInDb,
+      double freqInMHz,
+      double height) {
+    double h = math.max(height, 1.0);
+    double logAnchorDistance;
+    if (networkType == NetworkType.NR) {
+      logAnchorDistance =
+          Nr3gppPathLossModel.logAnchorDistanceKm(density, levelInDb, freqInMHz, h);
+    } else {
+      double intercept = AnalyticPathLossModel.hataInterceptDb(density, freqInMHz, h);
+      double slope = AnalyticPathLossModel.hataSlopeDb(h);
+      if (!intercept.isFinite || slope.abs() < 1e-9) return double.nan;
+      logAnchorDistance = (levelInDb - intercept) / slope;
+    }
+    if (!logAnchorDistance.isFinite) return double.nan;
+    return math.pow(10.0,
+            beta[PathLossCoefficients.idxB0] +
+                beta[PathLossCoefficients.idxB1] * logAnchorDistance)
+        .toDouble();
+  }
+
+  /// Hata-anchored inversion — frequency/height physics from the analytic model; only offset
+  /// (b0) and slope multiplier (b1) are learned.
+  static double _invertHataCorrection(List<double> beta, CityDensity density,
+      double levelInDb, double freqInMHz, double height) {
+    double h = math.max(height, 1.0);
+    double intercept = AnalyticPathLossModel.hataInterceptDb(density, freqInMHz, h);
+    double slope = beta[PathLossCoefficients.idxB1] * AnalyticPathLossModel.hataSlopeDb(h);
+    if (!intercept.isFinite || slope.abs() < 1e-9) return double.nan;
+    double numerator = levelInDb - intercept - beta[PathLossCoefficients.idxB0];
+    return math.pow(10.0, numerator / slope).toDouble();
+  }
+
+  static double _invertLogDistance(
+      List<double> beta, double levelInDb, double freqInMHz, double height) {
+    double logFreq = log10(freqInMHz);
+    double logHeight = log10(math.max(height, 1.0));
+    double numerator = levelInDb -
+        beta[PathLossCoefficients.idxB0] -
+        beta[PathLossCoefficients.idxB2] * logFreq -
+        beta[PathLossCoefficients.idxB3] * logHeight;
+    double exponent = numerator / beta[PathLossCoefficients.idxB1];
+    return math.pow(10.0, exponent).toDouble();
+  }
+
+  static bool _isUsable(double distanceKm) =>
+      distanceKm.isFinite && distanceKm > 0;
+}

--- a/lib/pathloss/linear_regression.dart
+++ b/lib/pathloss/linear_regression.dart
@@ -1,0 +1,102 @@
+import 'dart:math' as math;
+
+/// Ordinary-least-squares multiple linear regression solved via the normal equations
+/// (XᵀX)β = Xᵀy using Gaussian elimination with partial pivoting. Pure Dart — no external ML
+/// dependency — so it runs on-device and in unit tests as well as in the trainer.
+///
+/// Ported from the Java `au.com.bitbot.phonetowers.pathloss.LinearRegression`.
+class LinearRegression {
+  LinearRegression._();
+
+  /// Fit y = X·β by minimising Σ(yᵢ - xᵢ·β)².
+  ///
+  /// [x] design matrix; rows = samples, columns = features (include a constant column of 1s
+  /// for the intercept). [y] response vector; length must equal the number of rows of x.
+  /// Returns β coefficients, length = number of columns of x.
+  static List<double> fit(List<List<double>> x, List<double> y) {
+    int n = x.length;
+    if (n == 0) {
+      throw ArgumentError('No samples');
+    }
+    int k = x[0].length;
+    if (y.length != n) {
+      throw ArgumentError('x/y row count mismatch');
+    }
+
+    List<List<double>> xtx = List.generate(k, (_) => List.filled(k, 0.0));
+    List<double> xty = List.filled(k, 0.0);
+    for (int i = 0; i < n; i++) {
+      for (int a = 0; a < k; a++) {
+        xty[a] += x[i][a] * y[i];
+        for (int b = 0; b < k; b++) {
+          xtx[a][b] += x[i][a] * x[i][b];
+        }
+      }
+    }
+    return _solve(xtx, xty);
+  }
+
+  /// Solve A·x = b for square A (A is modified in place). Uses partial pivoting.
+  static List<double> _solve(List<List<double>> a, List<double> b) {
+    int n = b.length;
+    for (int col = 0; col < n; col++) {
+      int pivot = col;
+      for (int r = col + 1; r < n; r++) {
+        if (a[r][col].abs() > a[pivot][col].abs()) {
+          pivot = r;
+        }
+      }
+      if (a[pivot][col].abs() < 1e-12) {
+        throw ArgumentError('Singular design matrix at column $col');
+      }
+      if (pivot != col) {
+        List<double> tmp = a[pivot];
+        a[pivot] = a[col];
+        a[col] = tmp;
+        double tb = b[pivot];
+        b[pivot] = b[col];
+        b[col] = tb;
+      }
+      for (int r = col + 1; r < n; r++) {
+        double factor = a[r][col] / a[col][col];
+        for (int c = col; c < n; c++) {
+          a[r][c] -= factor * a[col][c];
+        }
+        b[r] -= factor * b[col];
+      }
+    }
+    List<double> x = List.filled(n, 0.0);
+    for (int i = n - 1; i >= 0; i--) {
+      double sum = b[i];
+      for (int j = i + 1; j < n; j++) {
+        sum -= a[i][j] * x[j];
+      }
+      x[i] = sum / a[i][i];
+    }
+    return x;
+  }
+
+  /// Coefficient of determination R² for a fitted model.
+  static double rSquared(
+      List<List<double>> x, List<double> y, List<double> beta) {
+    int n = y.length;
+    double mean = 0;
+    for (double v in y) {
+      mean += v;
+    }
+    mean /= n;
+    double ssTot = 0;
+    double ssRes = 0;
+    for (int i = 0; i < n; i++) {
+      double pred = 0;
+      for (int j = 0; j < beta.length; j++) {
+        pred += x[i][j] * beta[j];
+      }
+      double diff = y[i] - pred;
+      ssRes += diff * diff;
+      double dm = y[i] - mean;
+      ssTot += dm * dm;
+    }
+    return ssTot < 1e-12 ? 0 : 1 - ssRes / ssTot;
+  }
+}

--- a/lib/pathloss/linear_regression.dart
+++ b/lib/pathloss/linear_regression.dart
@@ -1,5 +1,3 @@
-import 'dart:math' as math;
-
 /// Ordinary-least-squares multiple linear regression solved via the normal equations
 /// (XᵀX)β = Xᵀy using Gaussian elimination with partial pivoting. Pure Dart — no external ML
 /// dependency — so it runs on-device and in unit tests as well as in the trainer.

--- a/lib/pathloss/nr3gpp_path_loss_model.dart
+++ b/lib/pathloss/nr3gpp_path_loss_model.dart
@@ -1,0 +1,176 @@
+import 'dart:math' as math;
+
+import 'package:phonetowers/helpers/network_type_helper.dart';
+import 'package:phonetowers/helpers/translate_frequencies.dart';
+import 'package:phonetowers/pathloss/path_loss_model.dart';
+import 'package:phonetowers/restful/get_licenceHRP.dart';
+
+/// 3GPP TR 38.901 (5G NR) path-loss anchor — the NR equivalent of
+/// [AnalyticPathLossModel]'s Hata decomposition. Used as the calibration anchor for 5G NR
+/// observations and as the runtime model when no learned NR coefficients exist.
+///
+/// 3GPP TR 38.901 defines three outdoor scenarios that map to the app's [CityDensity] enum:
+///   RMa  (Rural Macro)        -> OPEN / SUBURBAN
+///   UMa  (Urban Macro)        -> URBAN / METRO
+///   UMi-StreetCanyon          -> METRO
+///
+/// The key structural difference from Hata is the dual-slope (breakpoint) model: real
+/// propagation has a breakpoint distance d_BP = 4 * h'_BS * h'_UT * fc / c where the slope
+/// changes from ~20 dB/decade to ~40 dB/decade. Hata is single-slope and cannot represent
+/// this kink — which is why fitting Hata on 5G data produces NaN.
+///
+/// Ported from the Java `au.com.bitbot.phonetowers.pathloss.Nr3gppPathLossModel`.
+class Nr3gppPathLossModel implements PathLossModel {
+  static const double _c = 2.99792458e8; // speed of light (m/s)
+  static const double _hUt = 1.5; // default UE antenna height above ground [m]
+  static const double _hEff = 1.0; // effective antenna height correction constant
+  static const double _maxDistanceKm = 5.0; // model validity limit
+
+  @override
+  double calculateDistance(
+      CityDensity density, double levelInDb, double freqInMHz, double height) {
+    double hBs = math.max(height, 10.0);
+    double fcGHz = freqInMHz / 1000.0;
+    if (fcGHz < 0.5 || fcGHz > 100.0) {
+      fcGHz = _clamp(freqInMHz / 1000.0, 0.5, 100.0);
+    }
+    return _solveDistance(density, levelInDb, fcGHz, hBs);
+  }
+
+  @override
+  double calculateDistanceWithContext(int mnc, NetworkType networkType,
+      CityDensity density, double levelInDb, double freqInMHz, double height) {
+    return calculateDistance(density, levelInDb, freqInMHz, height);
+  }
+
+  /// The model's own log10(distanceKm) estimate for one observation — the anchor for calibration.
+  static double logAnchorDistanceKm(
+      CityDensity density, double levelInDb, double freqMHz, double height) {
+    double hBs = math.max(height, 10.0);
+    double fcGHz = _clamp(freqMHz / 1000.0, 0.5, 100.0);
+    double dKm = _solveDistance(density, levelInDb, fcGHz, hBs);
+    return (dKm.isFinite && dKm > 0) ? log10(dKm) : double.nan;
+  }
+
+  /// Solves the (piecewise) 3GPP path-loss formula for distance given a measured path loss in dB.
+  /// Uses bisection on the monotonic PL(d) function.
+  static double _solveDistance(
+      CityDensity density, double levelInDb, double fcGHz, double hBs) {
+    if (!levelInDb.isFinite || levelInDb <= 0) return double.nan;
+
+    double lo = 0.01; // 10 m
+    double hi = _maxDistanceKm; // 5 km
+    double plLo = _pathLossDb(density, lo, fcGHz, hBs);
+    double plHi = _pathLossDb(density, hi, fcGHz, hBs);
+    if (levelInDb <= plLo) return lo;
+    if (levelInDb >= plHi) return hi;
+
+    for (int i = 0; i < 60; i++) {
+      double mid = (lo + hi) / 2.0;
+      double plMid = _pathLossDb(density, mid, fcGHz, hBs);
+      if (plMid < levelInDb) {
+        lo = mid;
+      } else {
+        hi = mid;
+      }
+      if (hi - lo < 1e-6) break;
+    }
+    return (lo + hi) / 2.0;
+  }
+
+  static double _pathLossDb(
+      CityDensity density, double distanceKm, double fcGHz, double hBs) {
+    double d3d = distanceKm * 1000.0; // m
+    double fcHz = fcGHz * 1e9;
+    double hEffBs = math.max(hBs - _hEff, 1.0);
+    double hEffUt = math.max(_hUt - _hEff, 1.0);
+    double dBp = 4.0 * hEffBs * hEffUt * fcHz / _c;
+
+    switch (density) {
+      case CityDensity.OPEN:
+        return _rmaLosPathLoss(d3d, fcGHz, hBs, dBp);
+      case CityDensity.SUBURBAN:
+        return _rmaPathLoss(d3d, fcGHz, hBs, dBp);
+      case CityDensity.URBAN:
+        return _umaPathLoss(d3d, fcGHz, hBs, dBp);
+      case CityDensity.METRO:
+        return _umiPathLoss(d3d, fcGHz, hBs, dBp);
+      case CityDensity.MEDIUM:
+        return _umaPathLoss(d3d, fcGHz, hBs, dBp);
+    }
+  }
+
+  /// RMa (Rural Macro) — TR 38.901 §7.4.1. Default street width W=20m, avg building height h=5m.
+  static double _rmaPathLoss(double d3dM, double fcGHz, double hBs, double dBp) {
+    const double w = 20.0;
+    const double h = 5.0;
+    double plLos;
+    if (d3dM <= dBp) {
+      plLos = 20 * _log10(d3dM) + 20 * _log10(fcGHz) + 32.4;
+    } else {
+      plLos = 40 * _log10(d3dM) +
+          20 * _log10(fcGHz) -
+          9.5 * _log10(math.pow(dBp, 2) + math.pow(hBs - _hUt, 2));
+    }
+    double plNlos = 161.04 -
+        7.1 * _log10(w) +
+        7.5 * _log10(h) -
+        24.37 -
+        3.2 * math.pow(_log10(h), 2).toDouble() +
+        44.9 * _log10(d3dM) -
+        (1.5 * h - 0.8) * _log10(h) * _log10(d3dM) -
+        3.0 +
+        20 * _log10(fcGHz);
+    return math.max(plLos, plNlos);
+  }
+
+  /// RMa LOS-only path loss — for truly open areas (no buildings to create NLOS).
+  static double _rmaLosPathLoss(double d3dM, double fcGHz, double hBs, double dBp) {
+    if (d3dM <= dBp) {
+      return 20 * _log10(d3dM) + 20 * _log10(fcGHz) + 32.4;
+    }
+    return 40 * _log10(d3dM) +
+        20 * _log10(fcGHz) -
+        9.5 * _log10(math.pow(dBp, 2) + math.pow(hBs - _hUt, 2));
+  }
+
+  /// UMa (Urban Macro) — TR 38.901 §7.4.1.
+  static double _umaPathLoss(double d3dM, double fcGHz, double hBs, double dBp) {
+    double plLos;
+    if (d3dM <= dBp) {
+      plLos = 28.0 + 22.0 * _log10(d3dM) + 20.0 * _log10(fcGHz);
+    } else {
+      plLos = 28.0 +
+          40.0 * _log10(d3dM) +
+          20.0 * _log10(fcGHz) -
+          9.0 * _log10(math.pow(dBp, 2) + math.pow(hBs - _hUt, 2));
+    }
+    double plNlos =
+        13.54 + 39.08 * _log10(d3dM) + 20.0 * _log10(fcGHz) - 0.6 * (_hUt - 1.5);
+    return math.max(plLos, plNlos);
+  }
+
+  /// UMi-StreetCanyon — TR 38.901 §7.4.1.
+  static double _umiPathLoss(double d3dM, double fcGHz, double hBs, double dBp) {
+    double plLos;
+    if (d3dM <= dBp) {
+      plLos = 32.4 + 21.0 * _log10(d3dM) + 20.0 * _log10(fcGHz);
+    } else {
+      plLos = 32.4 +
+          40.0 * _log10(d3dM) +
+          20.0 * _log10(fcGHz) -
+          9.5 * _log10(math.pow(dBp, 2) + math.pow(hBs - _hUt, 2));
+    }
+    double plNlos = 32.4 +
+        35.8 * _log10(d3dM) +
+        20.0 * _log10(fcGHz) +
+        0.7 * (_hUt - 1.5) -
+        5.5 * _log10(math.max(hBs, 10.0));
+    return math.max(plLos, plNlos);
+  }
+
+  static double _log10(num x) => log10(math.max(x, 1e-10));
+
+  static double _clamp(double v, double lo, double hi) =>
+      math.max(lo, math.min(hi, v));
+}

--- a/lib/pathloss/path_loss_coefficients.dart
+++ b/lib/pathloss/path_loss_coefficients.dart
@@ -1,0 +1,179 @@
+import 'package:phonetowers/helpers/network_type_helper.dart';
+import 'package:phonetowers/pathloss/path_loss_key.dart';
+import 'package:phonetowers/restful/get_licenceHRP.dart';
+
+/// Per-environment learned coefficients for the log-distance path-loss model.
+///
+/// Coefficients are keyed either by [CityDensity] alone (the density-only fallback) or by a
+/// composite key `density|mnc|networkType|band` (see [PathLossKey]) so each telco / tech /
+/// band / density stratum gets its own b0..b3.
+///
+/// Three functional forms are supported, selected by [form]:
+/// - [formLogDistance]: levelInDb = b0 + b1·log10(d) + b2·log10(f) + b3·log10(h)
+/// - [formHataCorrection]: Hata-anchored inversion with learned offset (b0) and slope multiplier (b1)
+/// - [formHataCalibration]: regress log-distance on the analytic model's own log-distance estimate
+///
+/// Ported from the Java `au.com.bitbot.phonetowers.pathloss.PathLossCoefficients`.
+class PathLossCoefficients {
+  static const int numParams = 4;
+  static const int idxB0 = 0;
+  static const int idxB1 = 1;
+  static const int idxB2 = 2;
+  static const int idxB3 = 3;
+
+  static const String formLogDistance = 'log-distance';
+  static const String formHataCorrection = 'hata-correction';
+  static const String formHataCalibration = 'hata-calibration';
+
+  static const double defaultReferencePowerDbm = 57.0;
+
+  bool trained;
+  final double referencePowerDbm;
+  final String form;
+  final Map<String, List<double>> _coefficients = {};
+
+  PathLossCoefficients(this.trained, this.referencePowerDbm, [String? form])
+      : form = (form == null || form.isEmpty) ? formLogDistance : form;
+
+  bool get isHataCorrectionForm => form == formHataCorrection;
+  bool get isHataCalibrationForm => form == formHataCalibration;
+
+  void set(CityDensity density, List<double> beta, int sampleCount, double rSquared) {
+    _coefficients[PathLossKey.densityKey(density)] =
+        _pack(beta, sampleCount, rSquared);
+  }
+
+  void setComposite(int mnc, NetworkType networkType, String band,
+      CityDensity density, List<double> beta, int sampleCount, double rSquared) {
+    _coefficients[PathLossKey.compositeKey(mnc, networkType, band, density)] =
+        _pack(beta, sampleCount, rSquared);
+  }
+
+  static List<double> _pack(List<double> beta, int sampleCount, double rSquared) {
+    return [...beta, sampleCount.toDouble(), rSquared];
+  }
+
+  bool isTrainedFor(CityDensity density) =>
+      _coefficients.containsKey(PathLossKey.densityKey(density));
+
+  bool isTrainedComposite(int mnc, NetworkType networkType, String band,
+          CityDensity density) =>
+      _coefficients.containsKey(
+          PathLossKey.compositeKey(mnc, networkType, band, density));
+
+  bool get isAnyTrained => _coefficients.isNotEmpty;
+
+  bool get isTrained => trained && _coefficients.isNotEmpty;
+
+  List<double>? get(CityDensity density) =>
+      _coefficients[PathLossKey.densityKey(density)];
+
+  List<double>? getComposite(
+          int mnc, NetworkType networkType, String band, CityDensity density) =>
+      _coefficients[PathLossKey.compositeKey(mnc, networkType, band, density)];
+
+  Map<String, List<double>> get allComposite => Map.unmodifiable(_coefficients);
+
+  static PathLossCoefficients empty(
+          [double referencePowerDbm = defaultReferencePowerDbm]) =>
+      PathLossCoefficients(false, referencePowerDbm);
+
+  /// Serialise to the JSON format used by the bundled asset and the REST endpoint.
+  Map<String, dynamic> toJson() {
+    Map<String, dynamic> coeffs = {};
+    for (var entry in _coefficients.entries) {
+      List<double> v = entry.value;
+      coeffs[entry.key] = {
+        'b0': v[idxB0],
+        'b1': v[idxB1],
+        'b2': v[idxB2],
+        'b3': v[idxB3],
+        'sampleCount': v[numParams].toInt(),
+        'rSquared': v[numParams + 1],
+      };
+    }
+    return {
+      'trained': trained,
+      'referencePowerDbm': referencePowerDbm,
+      'form': form,
+      'coefficients': coeffs,
+    };
+  }
+
+  /// Parse from the JSON format used by the bundled asset and the REST endpoint's
+  /// converted output: `{"trained":true,"form":"...","referencePowerDbm":57,"coefficients":{...}}`.
+  static PathLossCoefficients fromJson(Map<String, dynamic> json) {
+    bool trained = json['trained'] ?? false;
+    double ref = _asDouble(json['referencePowerDbm'], defaultReferencePowerDbm);
+    String form = json['form'] is String
+        ? json['form'] as String
+        : formLogDistance;
+    PathLossCoefficients pc = PathLossCoefficients(trained, ref, form);
+
+    var coeffsObj = json['coefficients'];
+    if (coeffsObj is Map) {
+      for (var entry in coeffsObj.entries) {
+        String key = entry.key as String;
+        Map<String, dynamic> o = entry.value as Map<String, dynamic>;
+        List<double> beta = [
+          _asDouble(o['b0'], 0),
+          _asDouble(o['b1'], 0),
+          _asDouble(o['b2'], 0),
+          _asDouble(o['b3'], 0),
+        ];
+        int n = _asInt(o['sampleCount'], 0);
+        double r2 = _asDouble(o['rSquared'], 0);
+
+        if (key.contains('|')) {
+          List<String> parts = key.split('|');
+          if (parts.length == 4) {
+            CityDensity? d = _parseDensity(parts[0]);
+            if (d != null) {
+              int mnc = int.tryParse(parts[1]) ?? 0;
+              NetworkType nt = _parseNetworkType(parts[2]);
+              pc.setComposite(mnc, nt, parts[3], d, beta, n, r2);
+            }
+          }
+        } else {
+          CityDensity? d = _parseDensity(key);
+          if (d != null) {
+            pc.set(d, beta, n, r2);
+          }
+        }
+      }
+    }
+    return pc;
+  }
+
+  static double _asDouble(dynamic o, double def) {
+    if (o is num) return o.toDouble();
+    if (o is String) return double.tryParse(o) ?? def;
+    return def;
+  }
+
+  static int _asInt(dynamic o, int def) {
+    if (o is num) return o.toInt();
+    if (o is String) return int.tryParse(o) ?? def;
+    return def;
+  }
+
+  static NetworkType _parseNetworkType(String s) {
+    if (s == '?' || s.isEmpty) return NetworkType.UNKNOWN;
+    return NetworkType.values.firstWhere(
+      (e) => e.name == s,
+      orElse: () => NetworkType.UNKNOWN,
+    );
+  }
+
+  static CityDensity? _parseDensity(String key) {
+    for (CityDensity d in CityDensity.values) {
+      if (d.name.equalsIgnoreCase(key)) return d;
+    }
+    return null;
+  }
+}
+
+extension on String {
+  bool equalsIgnoreCase(String other) =>
+      toLowerCase() == other.toLowerCase();
+}

--- a/lib/pathloss/path_loss_key.dart
+++ b/lib/pathloss/path_loss_key.dart
@@ -1,0 +1,25 @@
+import 'package:phonetowers/helpers/network_type_helper.dart';
+import 'package:phonetowers/restful/get_licenceHRP.dart';
+
+/// Builds the grouping keys used by the learned path-loss model.
+///
+/// Ported from the Java `au.com.bitbot.phonetowers.pathloss.PathLossKey`.
+class PathLossKey {
+  PathLossKey._();
+
+  static String densityKey(CityDensity density) => density.name;
+
+  static String compositeKey(
+      int mnc, NetworkType networkType, String band, CityDensity density) {
+    return '${density.name}|$mnc|${networkType.name}|$band';
+  }
+
+  /// Bucket a carrier frequency (Hz) into LOW / MID / HIGH.
+  /// LOW < 1 GHz, MID 1-2.5 GHz, HIGH >= 2.5 GHz.
+  static String bandBucket(double freqHz) {
+    double fMHz = freqHz / 1_000_000.0;
+    if (fMHz < 1000.0) return 'LOW';
+    if (fMHz < 2500.0) return 'MID';
+    return 'HIGH';
+  }
+}

--- a/lib/pathloss/path_loss_model.dart
+++ b/lib/pathloss/path_loss_model.dart
@@ -1,0 +1,26 @@
+import 'package:phonetowers/helpers/network_type_helper.dart';
+import 'package:phonetowers/restful/get_licenceHRP.dart';
+
+/// Estimates the distance (km) at which a given signal path-loss is observed, for a carrier of a
+/// given frequency and a base station of a given antenna height, in a given environment.
+///
+/// This is the seam that lets the app swap the legacy Okumura-Hata / COST-231-Hata analytic
+/// formulas for a model whose constants are learned from real observations
+/// (see [LearnedPathLossModel]).
+///
+/// Ported from the Java `au.com.bitbot.phonetowers.pathloss.PathLossModel` interface.
+abstract class PathLossModel {
+  /// [density] environment (METRO / URBAN / MEDIUM / SUBURBAN / OPEN)
+  /// [levelInDb] path-loss magnitude in dB (power_dBm - receiver_dBm)
+  /// [freqInMHz] carrier frequency in MHz
+  /// [height] effective base-station antenna height in metres (tower height + hill height)
+  /// Returns estimated distance in km.
+  double calculateDistance(
+      CityDensity density, double levelInDb, double freqInMHz, double height);
+
+  /// Context-aware variant used at runtime. Selects the learned coefficients for the
+  /// (mnc, networkType, band, density) stratum (band derived from [freqInMHz]), falling
+  /// back to the density-only coefficients, then to the analytic model.
+  double calculateDistanceWithContext(int mnc, NetworkType networkType,
+      CityDensity density, double levelInDb, double freqInMHz, double height);
+}

--- a/lib/pathloss/path_loss_model_provider.dart
+++ b/lib/pathloss/path_loss_model_provider.dart
@@ -1,0 +1,90 @@
+import 'package:logger/logger.dart';
+import 'package:phonetowers/helpers/network_type_helper.dart';
+import 'package:phonetowers/pathloss/learned_path_loss_model.dart';
+import 'package:phonetowers/pathloss/path_loss_coefficients.dart';
+import 'package:phonetowers/pathloss/path_loss_model.dart';
+import 'package:phonetowers/restful/get_licenceHRP.dart';
+import 'package:phonetowers/restful/get_path_loss_coefficients.dart';
+
+/// Supplies the active [PathLossModel]. Fetches coefficients from the REST endpoint
+/// (MySQL `pathloss_coefficients` table) on startup; until that completes (or if it fails),
+/// the learned model falls back to the analytic Okumura-Hata / COST-231-Hata formulas,
+/// preserving today's behaviour.
+///
+/// Ported from the Java `au.com.bitbot.phonetowers.pathloss.PathLossModelProvider`.
+class PathLossModelProvider {
+  static final Logger _logger = Logger();
+
+  static PathLossModelProvider? _instance;
+
+  PathLossModelProvider._();
+
+  factory PathLossModelProvider() {
+    _instance ??= PathLossModelProvider._();
+    return _instance!;
+  }
+
+  PathLossModel? _model;
+  PathLossCoefficients? _coefficients;
+  bool _fetching = false;
+
+  PathLossModel get model {
+    _model ??= _build();
+    return _model!;
+  }
+
+  PathLossCoefficients? get coefficients {
+    // Ensure model is built so coefficients are populated
+    model;
+    return _coefficients;
+  }
+
+  /// Kick off an asynchronous fetch of coefficients from the server. Fire-and-forget —
+  /// the app continues with the analytic fallback until the fetch completes, at which
+  /// point the learned model is swapped in. Safe to call multiple times.
+  Future<void> init() async {
+    if (_fetching) return;
+    _fetching = true;
+    try {
+      PathLossCoefficients? serverCoeffs =
+          await GetPathLossCoefficients.fetchFromServer();
+      if (serverCoeffs != null && serverCoeffs.isAnyTrained) {
+        _logger.i('Using server-fetched path-loss coefficients '
+            '(form=${serverCoeffs.form}, groups=${serverCoeffs.allComposite.length})');
+        _coefficients = serverCoeffs;
+        _model = LearnedPathLossModel(serverCoeffs);
+      }
+    } catch (e) {
+      _logger.w('Server coefficient fetch failed, using analytic fallback: $e');
+    } finally {
+      _fetching = false;
+    }
+  }
+
+  PathLossModel _build() {
+    PathLossCoefficients coeffs =
+        _coefficients ?? PathLossCoefficients.empty();
+    _coefficients = coeffs;
+    return LearnedPathLossModel(coeffs);
+  }
+
+  /// Force a reload from the server (e.g. after coefficients are updated).
+  Future<void> reset() async {
+    _model = null;
+    _coefficients = null;
+    await init();
+  }
+
+  // Convenience static delegates mirroring the Java API.
+
+  static double calculateDistance(
+          CityDensity density, double levelInDb, double freqInMHz, double height) =>
+      PathLossModelProvider().model.calculateDistance(density, levelInDb, freqInMHz, height);
+
+  static double calculateDistanceWithContext(int mnc, NetworkType networkType,
+          CityDensity density, double levelInDb, double freqInMHz, double height) =>
+      PathLossModelProvider().model.calculateDistanceWithContext(
+          mnc, networkType, density, levelInDb, freqInMHz, height);
+
+  static Future<void> initProvider() => PathLossModelProvider().init();
+}

--- a/lib/restful/get_licenceHRP.dart
+++ b/lib/restful/get_licenceHRP.dart
@@ -119,7 +119,7 @@ class GetLicenceHRP {
 
         // Calculate the distance the signal will travel
         CityDensity model =
-            (device.getRadiationModel() ?? defaultRadiationModel) as CityDensity;
+            device.getRadiationModel() ?? defaultRadiationModel;
         double distanceKm = calculateDistance(
             model,
             freeSpaceLoss_dBi,

--- a/lib/restful/get_licenceHRP.dart
+++ b/lib/restful/get_licenceHRP.dart
@@ -3,7 +3,7 @@ import 'dart:math' as math;
 import 'package:dio/dio.dart';
 import 'package:google_maps_flutter_platform_interface/google_maps_flutter_platform_interface.dart';
 import 'package:logger/logger.dart';
-import 'package:phonetowers/helpers/translate_frequencies.dart';
+import 'package:phonetowers/pathloss/path_loss_model_provider.dart';
 import 'package:phonetowers/restful/get_elevation.dart';
 import 'package:phonetowers/helpers/network_type_helper.dart';
 import 'package:phonetowers/helpers/polygon_helper.dart';
@@ -167,74 +167,24 @@ class GetLicenceHRP {
     }
   }
 
-  // Distance in km
+  // Distance in km.
+  // The Okumura-Hata / COST-231-Hata analytic formulas are now delegated to the pluggable
+  // PathLossModel (see package:phonetowers/pathloss/). The active model is learned from real
+  // observations fetched from the server; until that completes (or if it fails), the learned
+  // model falls back to the analytic Hata/COST-231 formulas, preserving the original behaviour.
   static double calculateDistance(
       CityDensity density, double levelInDb, double freqInMHz, double height) {
-    double hb =
-        height; // base station antenna height above local terrain height [m]
-    double hm =
-        HEIGHT_RECEIVER_FROM_GROUND; // mobile station antenna height above local terrain height [m]
-    double fc = freqInMHz;
+    return PathLossModelProvider.calculateDistance(
+        density, levelInDb, freqInMHz, height);
+  }
 
-    // http://www.comlab.hut.fi/opetus/333/2004_2005_slides/Path_loss_models
-    double A = 69.55 + 26.16 * log10(fc) - 13.82 * log10(hb);
-    double B = 44.9 - 6.55 * log10(hb);
-
-    if (density == CityDensity.METRO) {
-      // COST 231-Hata model
-      // For medium to small cities
-      double E = (1.1 * log10(fc) - 0.7) * hm - (1.56 * log10(fc) - 0.8);
-      double F = 46.3 + 33.9 * log10(fc) - 13.82 * log10(hb);
-      // 0 dB medium sized cities and suburban areas
-      // 3 dB metropolitan areas
-      double G = 3;
-      // LdB = F + B * log10(R) – E + G
-      double R = math.pow(10, (levelInDb + E - F - G) / B) as double;
-      return R;
-    } else if (density == CityDensity.URBAN && freqInMHz >= 300) {
-      // Okumura-Hata model
-      // For large cities, fc >= 300MHz
-      double E = 3.2 * math.pow(log10(11.7554 * hm), 2) - 4.97;
-      // LdB = F + B * log10(R) – E + G
-      double R = math.pow(10, (levelInDb + E - A) / B) as double;
-      return R;
-    } else if (density == CityDensity.URBAN) {
-      // Okumura-Hata model
-      // For large cities, fc < 300MHz
-      double E = 8.29 * math.pow(log10(1.54 * hm), 2) - 1.1;
-      // LdB = F + B * log10(R) – E + G
-      double R = math.pow(10, (levelInDb + E - A) / B) as double;
-      return R;
-    } else if (density == CityDensity.MEDIUM) {
-      // Okumura-Hata model
-      // For medium to small cities
-      double E = (1.1 * log10(fc) - 0.7) * hm - (1.56 * log10(fc) - 0.8);
-      // LdB = A + B * log10(R) - E;
-      double R = math.pow(10, (levelInDb + E - A) / B) as double;
-      return R;
-    } else if (density == CityDensity.SUBURBAN) {
-      // Okumura-Hata model
-      // Suburban areas
-      double C = 2 * math.pow(log10(fc / 28), 2) + 5.4;
-      // Reach seems slightly too far, decrease by 4.42 dB since
-      // mean absolute error = 4.42 dB in urban environment
-      C -= 4.42;
-      // LdB = A + B * log10(R) - C;
-      double R = math.pow(10, (levelInDb + C - A) / B) as double;
-      return R;
-    } else if (density == CityDensity.OPEN) {
-      // Okumura-Hata model
-      // Open areas
-      double D = 4.78 * math.pow(log10(fc), 2) - 18.33 * log10(fc) + 40.94;
-      // Reach seems slightly too far, decrease by 4.42 dB since
-      // mean absolute error = 4.42 dB in urban environment
-      D -= 4.42 * 2;
-      // LdB = A + B * log10(R) - D;
-      double R = math.pow(10, (levelInDb + D - A) / B) as double;
-      return R;
-    } else {
-      return 0;
-    }
+  /// Context-aware overload (see PathLossModel.calculateDistanceWithContext). Selects the
+  /// learned coefficients for the (mnc, networkType, band, density) stratum, falling back to
+  /// density-only / analytic inside the model when no composite coefficients exist yet.
+  static double calculateDistanceWithContext(int mnc, NetworkType networkType,
+      CityDensity density, double levelInDb, double freqInMHz, double height) {
+    return PathLossModelProvider.calculateDistanceWithContext(
+        mnc, networkType, density, levelInDb, freqInMHz, height);
   }
 
   // Distance in km

--- a/lib/restful/get_path_loss_coefficients.dart
+++ b/lib/restful/get_path_loss_coefficients.dart
@@ -1,0 +1,134 @@
+import 'dart:convert';
+
+import 'package:dio/dio.dart';
+import 'package:logger/logger.dart';
+import 'package:phonetowers/networking/api.dart';
+import 'package:phonetowers/pathloss/path_loss_coefficients.dart';
+
+/// Fetches path-loss coefficients from the MySQL `pathloss_coefficients` table via the RESTify
+/// endpoint. Called asynchronously by [PathLossModelProvider.init] at startup. Falls back to
+/// the analytic Hata/COST-231 model if the fetch fails.
+///
+/// Ported from the Java `au.com.bitbot.phonetowers.restful.GetPathLossCoefficients`.
+class GetPathLossCoefficients {
+  static final Logger _logger = Logger();
+
+  static const String _path =
+      '/towers/pathloss_coefficients/?_view=json&_expand=no&_count=100';
+  static const Duration _timeout = Duration(seconds: 5);
+
+  GetPathLossCoefficients._();
+
+  /// Fetches coefficients from the server. Returns null if the fetch fails (caller falls
+  /// back to the analytic model).
+  static Future<PathLossCoefficients?> fetchFromServer() async {
+    try {
+      Api api = Api.initialize();
+      Response response = await api.dio.get(
+        _path,
+        options: Options(
+          sendTimeout: _timeout,
+          receiveTimeout: _timeout,
+        ),
+      );
+
+      if (response.statusCode == null ||
+          response.statusCode! < 200 ||
+          response.statusCode! >= 300) {
+        _logger.w('Server returned HTTP ${response.statusCode}, falling back');
+        return null;
+      }
+
+      Map<String, dynamic> json = response.data is String
+          ? jsonDecode(response.data)
+          : response.data as Map<String, dynamic>;
+
+      return _restifyRowsToCoefficients(json);
+    } catch (e) {
+      _logger.w('Could not fetch coefficients from server: $e');
+      return null;
+    }
+  }
+
+  /// Converts a RESTify JSON response ({"restify":{"rows":[...]}}) into a
+  /// [PathLossCoefficients] object.
+  static PathLossCoefficients? _restifyRowsToCoefficients(
+      Map<String, dynamic> restifyJson) {
+    try {
+      Map<String, dynamic> root = restifyJson;
+      if (root.containsKey('restify')) {
+        root = root['restify'] as Map<String, dynamic>;
+      }
+      List rows = root['rows'] as List;
+      if (rows.isEmpty) return null;
+
+      // Use the first row's form/trained/referencePowerDbm as the global values
+      Map<String, dynamic> firstRow =
+          (rows[0] as Map<String, dynamic>)['values'] as Map<String, dynamic>;
+      String form = _fieldValue(firstRow['form'], 'hata-calibration');
+      bool trained = _fieldInt(firstRow['trained'], 0) == 1;
+      double refPower = _fieldDouble(firstRow['reference_power_dbm'], 57.0);
+
+      Map<String, dynamic> result = {
+        'trained': trained,
+        'form': form,
+        'referencePowerDbm': refPower,
+        'coefficients': <String, dynamic>{},
+      };
+      Map<String, dynamic> coefficients = result['coefficients'];
+
+      for (var row in rows) {
+        Map<String, dynamic> values =
+            (row as Map<String, dynamic>)['values'] as Map<String, dynamic>;
+        String key = _fieldValue(values['coeff_key'], '');
+        if (key.isEmpty) continue;
+        coefficients[key] = {
+          'b0': _fieldDouble(values['b0'], 0),
+          'b1': _fieldDouble(values['b1'], 0),
+          'b2': _fieldDouble(values['b2'], 0),
+          'b3': _fieldDouble(values['b3'], 0),
+          'sampleCount': _fieldInt(values['sample_count'], 0),
+          'rSquared': _fieldDouble(values['r_squared'], 0),
+        };
+      }
+
+      PathLossCoefficients coeffs =
+          PathLossCoefficients.fromJson(result);
+      _logger.i('Loaded ${coeffs.isAnyTrained ? "trained" : "untrained"} '
+          'coefficients from server (form=${coeffs.form})');
+      return coeffs;
+    } catch (e) {
+      _logger.w('Could not parse RESTify response: $e');
+      return null;
+    }
+  }
+
+  /// Extract the "value" field from a RESTify column object as a String.
+  static String _fieldValue(dynamic col, String def) {
+    if (col is Map<String, dynamic>) {
+      var v = col['value'];
+      return v?.toString() ?? def;
+    }
+    return def;
+  }
+
+  /// Extract the "value" field from a RESTify column object as a double.
+  static double _fieldDouble(dynamic col, double def) {
+    if (col is Map<String, dynamic>) {
+      var v = col['value'];
+      if (v is num) return v.toDouble();
+      if (v is String) return double.tryParse(v) ?? def;
+    }
+    return def;
+  }
+
+  /// Extract the "value" field from a RESTify column object as an int.
+  static int _fieldInt(dynamic col, int def) {
+    if (col is Map<String, dynamic>) {
+      var v = col['value'];
+      if (v is num) return v.toInt();
+      if (v is String) return int.tryParse(v) ?? def;
+    }
+    return def;
+  }
+}

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -12,7 +12,7 @@ publish_to: 'none'
 # In iOS, build-name is used as CFBundleShortVersionString while build-number used as CFBundleVersion.
 # Read more about iOS versioning at
 # https://developer.apple.com/library/archive/documentation/General/Reference/InfoPlistKeyReference/Articles/CoreFoundationKeys.html
-version: 1.11.4+109
+version: 1.11.5+110
 
 environment:
   sdk: '>=3.9.2 <4.0.0'

--- a/test/pathloss/analytic_path_loss_model_test.dart
+++ b/test/pathloss/analytic_path_loss_model_test.dart
@@ -1,0 +1,113 @@
+import 'dart:math' as math;
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:phonetowers/pathloss/analytic_path_loss_model.dart';
+import 'package:phonetowers/restful/get_licenceHRP.dart';
+
+/// Pins the exact numeric outputs of the legacy Okumura-Hata / COST-231-Hata formulas
+/// (moved verbatim from GetLicenceHRP into AnalyticPathLossModel). These are the same
+/// assertions previously held by GetLicenceHRPTest, kept here so the reference
+/// implementation can never silently drift.
+///
+/// Ported from the Java `AnalyticPathLossModelTest`.
+void main() {
+  final model = AnalyticPathLossModel();
+
+  group('AnalyticPathLossModelTest', () {
+    test('metro', () {
+      expect(model.calculateDistance(CityDensity.METRO, 127.0, 1865.0, 30.0),
+          closeTo(0.39611, 1e-3));
+      expect(model.calculateDistance(CityDensity.METRO, 137.0, 1865.0, 30.0),
+          closeTo(0.76157, 1e-3));
+      expect(model.calculateDistance(CityDensity.METRO, 147.0, 1865.0, 30.0),
+          closeTo(1.46420, 1e-3));
+      expect(model.calculateDistance(CityDensity.METRO, 127.0, 2680.0, 30.0),
+          closeTo(0.27811, 1e-3));
+      expect(model.calculateDistance(CityDensity.METRO, 127.0, 763.0, 30.0),
+          closeTo(0.94720, 1e-3));
+      expect(model.calculateDistance(CityDensity.METRO, 127.0, 1865.0, 3.0),
+          closeTo(0.21382, 1e-3));
+      expect(model.calculateDistance(CityDensity.METRO, 127.0, 1865.0, 60.0),
+          closeTo(0.50012, 1e-3));
+    });
+
+    test('urban', () {
+      expect(model.calculateDistance(CityDensity.URBAN, 127.0, 1865.0, 30.0),
+          closeTo(0.55519, 1e-3));
+      expect(model.calculateDistance(CityDensity.URBAN, 137.0, 1865.0, 30.0),
+          closeTo(1.06742, 1e-3));
+      expect(model.calculateDistance(CityDensity.URBAN, 147.0, 1865.0, 30.0),
+          closeTo(2.05223, 1e-3));
+      expect(model.calculateDistance(CityDensity.URBAN, 127.0, 2680.0, 30.0),
+          closeTo(0.42414, 1e-3));
+      expect(model.calculateDistance(CityDensity.URBAN, 127.0, 763.0, 30.0),
+          closeTo(1.07823, 1e-3));
+      expect(model.calculateDistance(CityDensity.URBAN, 127.0, 1865.0, 3.0),
+          closeTo(0.28424, 1e-3));
+      expect(model.calculateDistance(CityDensity.URBAN, 127.0, 1865.0, 60.0),
+          closeTo(0.71515, 1e-3));
+    });
+
+    test('suburban', () {
+      expect(model.calculateDistance(CityDensity.SUBURBAN, 127.0, 1865.0, 30.0),
+          closeTo(0.99565, 1e-3));
+      expect(model.calculateDistance(CityDensity.SUBURBAN, 137.0, 1865.0, 30.0),
+          closeTo(1.91424, 1e-3));
+      expect(model.calculateDistance(CityDensity.SUBURBAN, 147.0, 1865.0, 30.0),
+          closeTo(3.68033, 1e-3));
+      expect(model.calculateDistance(CityDensity.SUBURBAN, 127.0, 2680.0, 30.0),
+          closeTo(0.82258, 1e-3));
+      expect(model.calculateDistance(CityDensity.SUBURBAN, 127.0, 763.0, 30.0),
+          closeTo(1.63880, 1e-3));
+      expect(model.calculateDistance(CityDensity.SUBURBAN, 127.0, 1865.0, 3.0),
+          closeTo(0.46513, 1e-3));
+      expect(model.calculateDistance(CityDensity.SUBURBAN, 127.0, 1865.0, 60.0),
+          closeTo(1.32770, 1e-3));
+    });
+
+    test('open', () {
+      expect(model.calculateDistance(CityDensity.OPEN, 127.0, 1865.0, 30.0),
+          closeTo(2.76969, 1e-3));
+      expect(model.calculateDistance(CityDensity.OPEN, 137.0, 1865.0, 30.0),
+          closeTo(5.32503, 1e-3));
+      expect(model.calculateDistance(CityDensity.OPEN, 147.0, 1865.0, 30.0),
+          closeTo(10.2379, 1e-3));
+      expect(model.calculateDistance(CityDensity.OPEN, 127.0, 2680.0, 30.0),
+          closeTo(2.43608, 1e-3));
+      expect(model.calculateDistance(CityDensity.OPEN, 127.0, 763.0, 30.0),
+          closeTo(4.06048, 1e-3));
+      expect(model.calculateDistance(CityDensity.OPEN, 127.0, 1865.0, 3.0),
+          closeTo(1.10215, 1e-3));
+      expect(model.calculateDistance(CityDensity.OPEN, 127.0, 1865.0, 60.0),
+          closeTo(3.92440, 1e-3));
+    });
+
+    /// The intercept/slope decomposition exposed for the Hata-anchored trained model must reproduce
+    /// calculateDistance exactly for every density, frequency and height. If this drifts, a trained
+    /// hata-correction asset would silently be anchored to a different model than the analytic
+    /// fallback it is meant to generalise.
+    test('interceptAndSlopeReproduceCalculateDistance', () {
+      List<double> levels = [110.0, 127.0, 150.0];
+      List<double> freqs = [200.0, 700.0, 1865.0, 2680.0, 3500.0];
+      List<double> heights = [3.0, 15.0, 30.0, 60.0];
+      for (CityDensity d in CityDensity.values) {
+        for (double level in levels) {
+          for (double f in freqs) {
+            for (double h in heights) {
+              double expected = model.calculateDistance(d, level, f, h);
+              double intercept = AnalyticPathLossModel.hataInterceptDb(d, f, h);
+              double slope = AnalyticPathLossModel.hataSlopeDb(h);
+              double actual =
+                  math.pow(10, (level - intercept) / slope).toDouble();
+              expect(
+                  actual,
+                  closeTo(
+                      expected, math.max(1e-9, expected.abs() * 1e-9)),
+                  reason: '$d level=$level f=$f h=$h');
+            }
+          }
+        }
+      }
+    });
+  });
+}

--- a/test/pathloss/learned_path_loss_model_test.dart
+++ b/test/pathloss/learned_path_loss_model_test.dart
@@ -1,0 +1,222 @@
+import 'dart:convert';
+import 'dart:math' as math;
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:phonetowers/helpers/network_type_helper.dart';
+import 'package:phonetowers/helpers/translate_frequencies.dart';
+import 'package:phonetowers/pathloss/analytic_path_loss_model.dart';
+import 'package:phonetowers/pathloss/learned_path_loss_model.dart';
+import 'package:phonetowers/pathloss/path_loss_coefficients.dart';
+import 'package:phonetowers/restful/get_licenceHRP.dart';
+
+/// Checks the learned model: it must fall back to the analytic Hata/COST-231 formulas when a density
+/// has no trained coefficients, and must exactly invert its own forward equation once trained.
+///
+/// Ported from the Java `LearnedPathLossModelTest`.
+void main() {
+  group('LearnedPathLossModelTest', () {
+    test('fallsBackToAnalyticWhenUntrained', () {
+      PathLossCoefficients empty = PathLossCoefficients.empty(57.0);
+      LearnedPathLossModel learned = LearnedPathLossModel(empty);
+      AnalyticPathLossModel analytic = AnalyticPathLossModel();
+      for (CityDensity d in CityDensity.values) {
+        double a = analytic.calculateDistance(d, 127.0, 1865.0, 30.0);
+        double l = learned.calculateDistance(d, 127.0, 1865.0, 30.0);
+        expect(l, closeTo(a, 1e-9), reason: 'density $d');
+      }
+    });
+
+    test('invertsTrainedCoefficients', () {
+      PathLossCoefficients coeffs = PathLossCoefficients.empty(57.0);
+      coeffs.set(CityDensity.URBAN, [100.0, 40.0, 0.0, 0.0], 1000, 0.95);
+      LearnedPathLossModel learned = LearnedPathLossModel(coeffs);
+
+      double levelFor2km = 100 + 40 * log10(2.0);
+      expect(learned.calculateDistance(CityDensity.URBAN, levelFor2km, 1865.0, 30.0),
+          closeTo(2.0, 1e-6));
+
+      double levelFor10km = 100 + 40 * log10(10.0);
+      expect(learned.calculateDistance(CityDensity.URBAN, levelFor10km, 1865.0, 30.0),
+          closeTo(10.0, 1e-6));
+    });
+
+    test('invertsTrainedCoefficientsWithFreqAndHeight', () {
+      PathLossCoefficients coeffs = PathLossCoefficients.empty(57.0);
+      coeffs.set(CityDensity.OPEN, [50.0, 35.0, 12.0, 8.0], 500, 0.9);
+      LearnedPathLossModel learned = LearnedPathLossModel(coeffs);
+
+      double f = 900.0, h = 45.0, d = 5.0;
+      double level = 50 + 35 * log10(d) + 12 * log10(f) + 8 * log10(h);
+      expect(learned.calculateDistance(CityDensity.OPEN, level, f, h),
+          closeTo(d, 1e-6));
+    });
+
+    /// The Hata-anchored form must reduce EXACTLY to the analytic model at the identity correction
+    /// (b0 = 0, b1 = 1). This is what makes the new formulation a strict generalisation of Hata rather
+    /// than a gamble: the worst a trained correction can do is drift away from a model we already ship.
+    test('hataCorrectionWithIdentityCoefficientsMatchesAnalytic', () {
+      PathLossCoefficients coeffs = PathLossCoefficients(
+          true, 57.0, PathLossCoefficients.formHataCorrection);
+      AnalyticPathLossModel analytic = AnalyticPathLossModel();
+      for (CityDensity d in CityDensity.values) {
+        coeffs.set(d, [0.0, 1.0, 0.0, 0.0], 1000, 0.5);
+      }
+      LearnedPathLossModel learned = LearnedPathLossModel(coeffs);
+      for (CityDensity d in CityDensity.values) {
+        for (double f in [700.0, 1865.0, 3500.0]) {
+          for (double h in [15.0, 30.0, 60.0]) {
+            double a = analytic.calculateDistance(d, 127.0, f, h);
+            double l = learned.calculateDistance(d, 127.0, f, h);
+            expect(l, closeTo(a, 1e-9), reason: '$d f=$f h=$h');
+          }
+        }
+      }
+    });
+
+    /// A learned correction must invert its own forward equation.
+    test('hataCorrectionInvertsItsOwnForwardEquation', () {
+      PathLossCoefficients coeffs = PathLossCoefficients(
+          true, 57.0, PathLossCoefficients.formHataCorrection);
+      double b0 = -6.5, b1 = 1.2;
+      coeffs.set(CityDensity.SUBURBAN, [b0, b1, 0.0, 0.0], 5000, 0.2);
+      LearnedPathLossModel learned = LearnedPathLossModel(coeffs);
+
+      double f = 1865.0, h = 30.0, d = 7.5;
+      double level = AnalyticPathLossModel.hataInterceptDb(CityDensity.SUBURBAN, f, h) +
+          b0 +
+          b1 * AnalyticPathLossModel.hataSlopeDb(h) * log10(d);
+      expect(learned.calculateDistance(CityDensity.SUBURBAN, level, f, h),
+          closeTo(d, 1e-6));
+    });
+
+    /// The calibration form must also reduce EXACTLY to the analytic model at b0=0, b1=1 — this is the
+    /// property that makes the shipped hata-calibration asset a safe generalisation of Hata.
+    test('hataCalibrationWithIdentityCoefficientsMatchesAnalytic', () {
+      PathLossCoefficients coeffs = PathLossCoefficients(
+          true, 57.0, PathLossCoefficients.formHataCalibration);
+      AnalyticPathLossModel analytic = AnalyticPathLossModel();
+      for (CityDensity d in CityDensity.values) {
+        coeffs.set(d, [0.0, 1.0, 0.0, 0.0], 1000, 0.1);
+      }
+      LearnedPathLossModel learned = LearnedPathLossModel(coeffs);
+      for (CityDensity d in CityDensity.values) {
+        for (double f in [700.0, 1865.0, 3500.0]) {
+          for (double h in [15.0, 30.0, 60.0]) {
+            expect(
+                learned.calculateDistance(d, 127.0, f, h),
+                closeTo(analytic.calculateDistance(d, 127.0, f, h), 1e-9),
+                reason: '$d f=$f h=$h');
+          }
+        }
+      }
+    });
+
+    /// The calibration form must apply the learned rescaling in log-distance space, and — crucially —
+    /// must stay bounded. The live-trained OPEN gain of 0.145 with the legacy inverted forward fit
+    /// produced 1e16 km; here a very weak signal must still yield a sane, finite distance.
+    test('hataCalibrationRescalesInLogSpaceAndStaysBounded', () {
+      PathLossCoefficients coeffs = PathLossCoefficients(
+          true, 57.0, PathLossCoefficients.formHataCalibration);
+      double b0 = 0.825, b1 = 0.145; // live-trained OPEN coefficients
+      coeffs.set(CityDensity.OPEN, [b0, b1, 0.0, 0.0], 153772, 0.014);
+      LearnedPathLossModel learned = LearnedPathLossModel(coeffs);
+      AnalyticPathLossModel analytic = AnalyticPathLossModel();
+
+      double f = 1865.0, h = 30.0;
+      for (double level in [100.0, 127.0, 160.0, 200.0]) {
+        double expected = math.pow(
+            10, b0 + b1 * log10(analytic.calculateDistance(CityDensity.OPEN, level, f, h))).toDouble();
+        double actual = learned.calculateDistance(CityDensity.OPEN, level, f, h);
+        expect(actual, closeTo(expected, 1e-6), reason: 'level=$level');
+        expect(actual < 1000.0, isTrue,
+            reason: 'level=$level must stay bounded, was $actual');
+      }
+    });
+
+    /// A positive gain must keep the model monotonic: weaker signal ⇒ farther, which tower ranking relies on.
+    test('hataCalibrationIsMonotonicInSignal', () {
+      PathLossCoefficients coeffs = PathLossCoefficients(
+          true, 57.0, PathLossCoefficients.formHataCalibration);
+      coeffs.set(CityDensity.SUBURBAN, [-0.106, 0.382, 0.0, 0.0], 38693, 0.107);
+      LearnedPathLossModel learned = LearnedPathLossModel(coeffs);
+      double previous = 0;
+      for (double level = 100.0; level <= 170.0; level += 5.0) {
+        double d = learned.calculateDistance(CityDensity.SUBURBAN, level, 1865.0, 30.0);
+        expect(d > previous, isTrue,
+            reason: 'distance must increase with path loss at level=$level');
+        previous = d;
+      }
+    });
+
+    /// The form flag must survive a JSON round trip, or a trained asset would be inverted wrongly.
+    test('formSurvivesJsonRoundTrip', () {
+      PathLossCoefficients coeffs = PathLossCoefficients(
+          true, 57.0, PathLossCoefficients.formHataCorrection);
+      coeffs.set(CityDensity.OPEN, [-3.0, 1.1, 0.0, 0.0], 900, 0.15);
+      String json = jsonEncode(coeffs.toJson());
+      PathLossCoefficients parsed =
+          PathLossCoefficients.fromJson(jsonDecode(json));
+      expect(parsed.form, PathLossCoefficients.formHataCorrection);
+      expect(parsed.isHataCorrectionForm, isTrue);
+      expect(parsed.get(CityDensity.OPEN)![1], closeTo(1.1, 1e-9));
+    });
+
+    /// Assets written before the form field existed must keep the legacy log-distance behaviour.
+    test('legacyAssetWithoutFormDefaultsToLogDistance', () {
+      String json = '{"trained":true,"referencePowerDbm":57,"coefficients":'
+          '{"URBAN":{"b0":100.0,"b1":40.0,"b2":0.0,"b3":0.0,"sampleCount":10,"rSquared":0.5}}}';
+      PathLossCoefficients parsed =
+          PathLossCoefficients.fromJson(jsonDecode(json));
+      expect(parsed.form, PathLossCoefficients.formLogDistance);
+      LearnedPathLossModel learned = LearnedPathLossModel(parsed);
+      expect(
+          learned.calculateDistance(
+              CityDensity.URBAN, 100 + 40 * log10(2.0), 1865.0, 30.0),
+          closeTo(2.0, 1e-6));
+    });
+
+    /// Pins the exact gap the coverage-polygon estimate fix closed. The on-device "estimated polygon"
+    /// (PolygonHelper.createBasicPolygon) is drawn for transmitters that have no real antenna pattern.
+    /// Before the fix it called the density-only calculateDistance overload, which for SUBURBAN/METRO
+    /// (which have no trained density-only group) silently fell back to analytic Hata. The fix routes
+    /// it through the composite calculateDistanceWithContext overload used by the tower-mapping path.
+    test('compositeOverloadUsesTrainedSuburbanLteWhenDensityOnlyAbsent', () {
+      PathLossCoefficients coeffs = PathLossCoefficients(
+          true, 57.0, PathLossCoefficients.formHataCalibration);
+      coeffs.setComposite(1, NetworkType.LTE, 'MID', CityDensity.SUBURBAN,
+          [-0.3108574332021878, 0.38223136074523323, 0.0, 0.0], 13724, 0.1059);
+      LearnedPathLossModel learned = LearnedPathLossModel(coeffs);
+      AnalyticPathLossModel analytic = AnalyticPathLossModel();
+
+      double f = 1800.0, h = 30.0, level = 127.0;
+      double trained = learned.calculateDistanceWithContext(
+          1, NetworkType.LTE, CityDensity.SUBURBAN, level, f, h);
+      double analyticOnly = analytic.calculateDistance(CityDensity.SUBURBAN, level, f, h);
+
+      expect(trained > 0 && trained.isFinite, isTrue,
+          reason: 'trained distance must be finite and positive');
+      expect((trained - analyticOnly).abs() > 1e-6, isTrue,
+          reason:
+              'composite overload must apply the trained group, not fall back to analytic Hata');
+
+      double oldPath = learned.calculateDistance(CityDensity.SUBURBAN, level, f, h);
+      expect(oldPath, closeTo(analyticOnly, 1e-9),
+          reason:
+              'density-only overload falls back to analytic when no density-only group exists');
+    });
+
+    test('roundTripsThroughJson', () {
+      PathLossCoefficients coeffs = PathLossCoefficients.empty(57.0);
+      coeffs.set(CityDensity.SUBURBAN, [80.0, 38.0, 10.0, 6.0], 250, 0.88);
+      String json = jsonEncode(coeffs.toJson());
+      PathLossCoefficients parsed =
+          PathLossCoefficients.fromJson(jsonDecode(json));
+      expect(parsed.isTrainedFor(CityDensity.SUBURBAN), isTrue);
+      List<double> b = parsed.get(CityDensity.SUBURBAN)!;
+      expect(b[0], closeTo(80.0, 1e-9));
+      expect(b[1], closeTo(38.0, 1e-9));
+      expect(b[2], closeTo(10.0, 1e-9));
+      expect(b[3], closeTo(6.0, 1e-9));
+    });
+  });
+}

--- a/test/pathloss/linear_regression_test.dart
+++ b/test/pathloss/linear_regression_test.dart
@@ -1,0 +1,53 @@
+import 'dart:math';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:phonetowers/pathloss/linear_regression.dart';
+
+/// Deterministic checks for the ordinary-least-squares solver.
+///
+/// Ported from the Java `LinearRegressionTest`.
+void main() {
+  group('LinearRegressionTest', () {
+    test('fitsExactLinearRelationship', () {
+      // y = 2 + 3*x1 - 1*x2
+      List<List<double>> x = List.generate(200, (_) => List.filled(3, 0.0));
+      List<double> y = List.filled(200, 0.0);
+      Random r = Random(42);
+      for (int i = 0; i < 200; i++) {
+        x[i][0] = 1.0;
+        x[i][1] = r.nextDouble() * 10;
+        x[i][2] = r.nextDouble() * 5;
+        y[i] = 2 + 3 * x[i][1] - 1 * x[i][2];
+      }
+      List<double> beta = LinearRegression.fit(x, y);
+      expect(beta[0], closeTo(2.0, 1e-9));
+      expect(beta[1], closeTo(3.0, 1e-9));
+      expect(beta[2], closeTo(-1.0, 1e-9));
+      expect(LinearRegression.rSquared(x, y, beta), closeTo(1.0, 1e-9));
+    });
+
+    test('fitsWithNoise', () {
+      List<List<double>> x = List.generate(500, (_) => List.filled(2, 0.0));
+      List<double> y = List.filled(500, 0.0);
+      Random r = Random(7);
+      for (int i = 0; i < 500; i++) {
+        x[i][0] = 1.0;
+        x[i][1] = r.nextDouble() * 100;
+        y[i] = 5 + 2.5 * x[i][1] + (r.nextDouble() - 0.5); // small noise
+      }
+      List<double> beta = LinearRegression.fit(x, y);
+      expect(beta[0], closeTo(5.0, 0.05));
+      expect(beta[1], closeTo(2.5, 0.01));
+      expect(LinearRegression.rSquared(x, y, beta), closeTo(1.0, 0.001));
+    });
+
+    test('rejectsSingularMatrix', () {
+      List<List<double>> x = [
+        [1.0, 2.0],
+        [2.0, 4.0]
+      ]; // columns linearly dependent
+      List<double> y = [1.0, 2.0];
+      expect(() => LinearRegression.fit(x, y), throwsArgumentError);
+    });
+  });
+}

--- a/test/pathloss/nr3gpp_path_loss_model_test.dart
+++ b/test/pathloss/nr3gpp_path_loss_model_test.dart
@@ -1,0 +1,95 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:phonetowers/helpers/network_type_helper.dart';
+import 'package:phonetowers/pathloss/analytic_path_loss_model.dart';
+import 'package:phonetowers/pathloss/learned_path_loss_model.dart';
+import 'package:phonetowers/pathloss/nr3gpp_path_loss_model.dart';
+import 'package:phonetowers/pathloss/path_loss_coefficients.dart';
+import 'package:phonetowers/restful/get_licenceHRP.dart';
+
+/// Unit tests for Nr3gppPathLossModel — the 3GPP TR 38.901 (5G NR) path-loss anchor.
+///
+/// Verifies that the model produces finite, positive distances for all density environments at
+/// 5G frequencies (3.5 GHz), that the dual-slope breakpoint behaviour is present, and that
+/// b0=0, b1=1 calibration reproduces the anchor exactly.
+///
+/// Ported from the Java `Nr3gppPathLossModelTest`.
+void main() {
+  const double fc5gMHz = 3500.0; // 3.5 GHz — common Australian 5G n78 band
+  const double towerHeightM = 25.0;
+  const double eps = 1e-6;
+
+  final model = Nr3gppPathLossModel();
+
+  group('Nr3gppPathLossModelTest', () {
+    test('allDensitiesProduceFinitePositiveDistancesAt5G', () {
+      double levelDb = 120.0;
+      for (CityDensity d in CityDensity.values) {
+        double km = model.calculateDistance(d, levelDb, fc5gMHz, towerHeightM);
+        expect(km.isFinite, isTrue,
+            reason: 'Density $d: distance must be finite, got $km');
+        expect(km > 0, isTrue,
+            reason: 'Density $d: distance must be positive, got $km');
+      }
+    });
+
+    test('higherPathLossGivesGreaterDistance', () {
+      double d1 =
+          model.calculateDistance(CityDensity.URBAN, 100.0, fc5gMHz, towerHeightM);
+      double d2 =
+          model.calculateDistance(CityDensity.URBAN, 130.0, fc5gMHz, towerHeightM);
+      expect(d2 > d1, isTrue,
+          reason:
+              'Higher path loss should give greater distance (d1=$d1, d2=$d2)');
+    });
+
+    test('logAnchorDistanceIsMonotonic', () {
+      double log1 = Nr3gppPathLossModel.logAnchorDistanceKm(
+          CityDensity.URBAN, 100.0, fc5gMHz, towerHeightM);
+      double log2 = Nr3gppPathLossModel.logAnchorDistanceKm(
+          CityDensity.URBAN, 130.0, fc5gMHz, towerHeightM);
+      expect(log2 > log1, isTrue,
+          reason: 'log anchor distance must increase with path loss');
+    });
+
+    test('b0ZeroB1OneReproducesAnchor', () {
+      PathLossCoefficients coeffs = PathLossCoefficients(
+          true, 57.0, PathLossCoefficients.formHataCalibration);
+      coeffs.set(CityDensity.URBAN, [0.0, 1.0, 0.0, 0.0], 100, 0.9);
+      LearnedPathLossModel learned =
+          LearnedPathLossModel(coeffs, AnalyticPathLossModel());
+
+      double levelDb = 120.0;
+      double anchorKm =
+          model.calculateDistance(CityDensity.URBAN, levelDb, fc5gMHz, towerHeightM);
+      double learnedKm = learned.calculateDistanceWithContext(
+          0, NetworkType.NR, CityDensity.URBAN, levelDb, fc5gMHz, towerHeightM);
+      expect(learnedKm, closeTo(anchorKm, eps),
+          reason: 'b0=0,b1=1 should reproduce the 3GPP anchor');
+    });
+
+    test('nrFallbackWhenNoLearnedCoefficients', () {
+      PathLossCoefficients coeffs = PathLossCoefficients.empty(57.0);
+      LearnedPathLossModel learned =
+          LearnedPathLossModel(coeffs, AnalyticPathLossModel());
+
+      double levelDb = 120.0;
+      double anchorKm =
+          model.calculateDistance(CityDensity.URBAN, levelDb, fc5gMHz, towerHeightM);
+      double learnedKm = learned.calculateDistanceWithContext(
+          0, NetworkType.NR, CityDensity.URBAN, levelDb, fc5gMHz, towerHeightM);
+      expect(learnedKm, closeTo(anchorKm, eps),
+          reason: 'NR with no coefficients should use 3GPP anchor');
+    });
+
+    test('openIsLessLossyThanMetro', () {
+      double levelDb = 120.0;
+      double openKm =
+          model.calculateDistance(CityDensity.OPEN, levelDb, fc5gMHz, towerHeightM);
+      double metroKm = model.calculateDistance(
+          CityDensity.METRO, levelDb, fc5gMHz, towerHeightM);
+      expect(openKm > metroKm, isTrue,
+          reason:
+              'OPEN should give greater distance than METRO at same path loss (open=$openKm, metro=$metroKm)');
+    });
+  });
+}


### PR DESCRIPTION
## Summary

Ports the path loss algorithm from the Java Android app (`aus_phone_towers_java`) to this iPhone Flutter app. The algorithm estimates distance from signal path-loss using **learned coefficients** fetched from the REST API (`/api/towers/pathloss_coefficients/`), with analytic Hata/COST-231 and 3GPP TR 38.901 models as fallbacks. This makes the iPhone app draw the **same polygon shapes and distances** as the Android app.

The Java app trains the coefficients server-side from crowd-sourced signal observations and writes them to the MySQL `pathloss_coefficients` table. This iPhone app only reads them — no tuning code is included.

## Changes

### New path loss module (`lib/pathloss/`)
| File | Description |
| --- | --- |
| `path_loss_model.dart` | `PathLossModel` interface |
| `analytic_path_loss_model.dart` | Okumura-Hata / COST-231-Hata closed-form formulas (fallback) |
| `nr3gpp_path_loss_model.dart` | 3GPP TR 38.901 (5G NR) anchor |
| `learned_path_loss_model.dart` | Trained model with 3 functional forms (log-distance, hata-correction, hata-calibration) |
| `path_loss_coefficients.dart` | Coefficient container with JSON serialisation |
| `path_loss_key.dart` | Composite key builder (mnc/networkType/band/density) |
| `path_loss_model_provider.dart` | Singleton provider — fetches from REST on startup, falls back to analytic |
| `linear_regression.dart` | OLS solver (used by tests) |

### REST client
- `lib/restful/get_path_loss_coefficients.dart` — fetches trained coefficients from the restifydb API

### Wiring
- `get_licenceHRP.dart` — `calculateDistance` delegates to `PathLossModelProvider`; context-aware overload uses composite lookup
- `polygon_helper.dart` — `createBasicPolygon` uses composite context lookup (matching Android's mapping path)
- `main.dart` — provider initialised fire-and-forget after secrets loaded

### Tests (26 tests, all passing — ported from Java)
- `analytic_path_loss_model_test.dart` — pins exact Hata formula numeric outputs
- `nr3gpp_path_loss_model_test.dart` — 3GPP 38.901 model behaviour
- `learned_path_loss_model_test.dart` — fallback, inversion, JSON round-trip, composite overload
- `linear_regression_test.dart` — OLS solver correctness

### Pre-existing warning fixes (separate commit)
- Removed unnecessary `as CityDensity` casts in `polygon_helper.dart` and `get_licenceHRP.dart`
- Removed unused `status`/`uuid` local variables in `main.dart`

### Documentation (separate commit)
- Created `AGENTS.md` as canonical agent instructions (recognised by all AI coding agents)
- Updated `.clinerules` to point to `AGENTS.md`
- Updated `README.md` with path loss algorithm section

## Version
Bumps version from `1.11.4+109` → `1.11.5+110`

---

_This PR was created by an AI agent (OpenHands) on behalf of @bradrushworth._