### PR TITLE
Port Android features (menu regroup, refarming, polygon precision, follow GPS, export towers) + fix label placement

### DIFF
--- a/docs/USER_GUIDE.md
+++ b/docs/USER_GUIDE.md
@@ -18,6 +18,12 @@ datasets and draws each transmitter on a Google Map together with its estimated 
 - **Coverage polygons** — coloured shaded areas showing the estimated coverage of each antenna.
   The colour matches the carrier (see the legend below). Toggle the outline with **Show/Hide
   Borders**.
+- **Coverage labels** — each tower's outermost coverage ring carries a small text label showing its
+  **frequency and technology** (e.g. `850 MHz 4G LTE`). The label is pinned to the point on that
+  ring that is *furthest* from the tower, so it sits on the outer edge of the coverage area rather
+  than piling up on top of the site marker. Because HRP coverage rings are irregular (terrain,
+  hills, sector directions), the label may appear at a different angle for each tower — that is
+  expected. Tapping a tower redraws its coverage and refreshes the label position.
 - **Your location** — a semi‑transparent azure dot (requires Location permission). Use the
   **Follow GPS** menu item to keep the map centred on you as you move ("drive mode").
 

--- a/docs/USER_GUIDE.md
+++ b/docs/USER_GUIDE.md
@@ -18,12 +18,13 @@ datasets and draws each transmitter on a Google Map together with its estimated 
 - **Coverage polygons** — coloured shaded areas showing the estimated coverage of each antenna.
   The colour matches the carrier (see the legend below). Toggle the outline with **Show/Hide
   Borders**.
-- **Coverage labels** — each tower's outermost coverage ring carries a small text label showing its
-  **frequency and technology** (e.g. `850 MHz 4G LTE`). The label is pinned to the point on that
-  ring that is *furthest* from the tower, so it sits on the outer edge of the coverage area rather
-  than piling up on top of the site marker. Because HRP coverage rings are irregular (terrain,
-  hills, sector directions), the label may appear at a different angle for each tower — that is
-  expected. Tapping a tower redraws its coverage and refreshes the label position.
+- **Coverage labels** — each tower's coverage carries a small text label showing its
+  **frequency and technology** (e.g. `850 MHz 4G LTE`). The label is placed *outside* the shaded
+  polygon — anchored on the point of the outermost ring that is furthest from the tower, then pushed
+  a little further out — so it sits in clear space instead of on top of the coverage fill or the
+  site marker. Because HRP coverage rings are irregular (terrain, hills, sector directions), the
+  label may appear at a different angle for each tower — that is expected. Tapping a tower redraws
+  its coverage and refreshes the label position.
 - **Your location** — a semi‑transparent azure dot (requires Location permission). Use the
   **Follow GPS** menu item to keep the map centred on you as you move ("drive mode").
 

--- a/docs/USER_GUIDE.md
+++ b/docs/USER_GUIDE.md
@@ -18,8 +18,8 @@ datasets and draws each transmitter on a Google Map together with its estimated 
 - **Coverage polygons** — coloured shaded areas showing the estimated coverage of each antenna.
   The colour matches the carrier (see the legend below). Toggle the outline with **Show/Hide
   Borders**.
-- **Your location** — a semi‑transparent azure dot (requires Location permission). The app can
-  centre the map on you; there is no automatic "follow while driving" mode yet.
+- **Your location** — a semi‑transparent azure dot (requires Location permission). Use the
+  **Follow GPS** menu item to keep the map centred on you as you move ("drive mode").
 
 ## 2. Colour & symbol legend
 
@@ -39,25 +39,43 @@ Tower markers use carrier logo icons. The colours below are used for the **cover
 
 ## 3. Toolbar menu (top‑right `⋯`)
 
+The menu is grouped the same way as the Android app:
+
+- **Reload Everything** — clear the map and re‑download all towers for the current area.
+- **Follow GPS** — toggle "drive mode". When on, the map stays centred on your location as you
+  move (uses more battery). When off, the map stops recentring.
 - **Show / Hide Borders** — toggle the radiation polygon outlines.
 - **Search Sites** — find a specific tower / site.
-- **Reload Everything** — clear the map and re‑download all towers for the current area.
 - **Map Mode** — Terrain / Hybrid / Satellite / Normal base map.
-- **Hiding Menu** — Hide / Show Radiation on Click (draw a tower's coverage polygon when you tap it).
+- **Hiding Menu** — a sub‑menu:
+  - **Hide / Show Radiation on Click** — when on (default), tapping a tower draws its coverage
+    polygon; when off, tapping does nothing.
+  - **Disable frequency refarming** — when ticked, legacy 3G (UMTS) licences that now run as 4G/5G
+    (e.g. band‑refarmed 900/2100 MHz) are shown at their *literal* licence type (3G UMTS) instead
+    of being re‑classified to their current reuse (4G LTE). Changing this reloads the towers.
+- **Export Data** — a sub‑menu:
+  - **Export Towers (GeoJSON)** — one point per tower (carrier, generation, frequency, azimuth,
+    height, EIRP, …) for every tower currently on the map.
+  - **Export Towers (CSV)** — the same data as a CSV.
+  - **Export Coverage (GeoJSON)** — the coverage polygons currently drawn on the map (with their
+    tower/device details) to GeoJSON, CSV and KML, timestamped, for use in QGIS / Google Earth.
+- **Polygon Precision** — how many points make up each coverage ring: **Low** (faster, blockier),
+  **Medium** (default) or **High** (smoother, more points). Applies to newly drawn coverage.
 - **Remove Ads** — buy *1 Year Ad‑Free* or *Permanent Ad‑Free* to remove the banner
   advertisement. The purchase is restored automatically on future launches (tap **Restore
   Purchases** if needed). The yearly option reverts to showing ads after 12 months and can be
   bought again; the permanent option never expires.
 - **Donate** — support development with a one‑off in‑app purchase (small / medium / large).
   Donations are repeatable and do **not** remove ads (not shown on the Web build).
-- **Developer / Regular Mode** — show extra diagnostic overlays.
-- **Report Problem** — take a screenshot to send feedback.
-- **Export** — save the coverage polygons currently drawn on the map (with their tower and device
-  details) to **GeoJSON**, **CSV** and **KML** files in the app's documents folder. The three files
-  are timestamped and can be opened in GIS tools such as QGIS or Google Earth. If no polygons are
-  drawn, nothing is exported.
-- **Links** — Rate App, AusPhoneTowers.com.au, iOS App Store, Source Code.
-- **User Guide** — opens this page.
+- **Problems Menu** — a sub‑menu:
+  - **Developer / Regular Mode** — show extra diagnostic overlays.
+  - **User Guide** — opens this page (the top‑right menu item that previously opened the wrong
+    page has been fixed).
+  - **Report Problem** — take a screenshot to send feedback.
+  - **Links** — Rate App, AusPhoneTowers.com.au, iOS App Store, Source Code.
+- **Rate App** — open the App Store review prompt.
+- **Close App** — on Android this exits the app; on iPhone/Web it isn't permitted by the OS, so a
+  hint is shown instead.
 
 ## 4. Navigation‑drawer filters
 
@@ -94,11 +112,15 @@ Open the drawer (top‑left) to control what is shown:
 | Connected‑tower / Cell Info bar | Yes | Not yet |
 | Timing‑advance ring | Yes | Not yet |
 | Observation markers (yellow / orange) | Yes | Not yet |
-| Follow‑GPS drive mode | Yes | Not yet |
+| Follow‑GPS drive mode | Yes | Yes |
+| Frequency refarming toggle (literal vs reuse) | Yes | Yes |
+| Polygon precision (point count) control | Yes | Yes |
+| Export Towers (GeoJSON/CSV) | Yes | Yes |
+| Export Coverage (GeoJSON/CSV/KML) | Yes | Yes (GeoJSON/CSV/KML) |
 | Shows your location dot | Yes | Yes (azure dot) |
 
 ## 7. Feedback & support
 
-Use **Report Problem** (screenshot) or the **Links** menu (Rate App / AusPhoneTowers.com.au /
-iOS App Store / Source Code). The Web/iOS app is still under active development — feedback is
-welcome at bitbot@bitbot.com.au.
+Use **Report Problem** (in the **Problems Menu**) or the **Problems Menu → Links** (Rate App /
+AusPhoneTowers.com.au / iOS App Store / Source Code). The Web/iOS app is still under active
+development — feedback is welcome at bitbot@bitbot.com.au.

--- a/lib/helpers/export_helper.dart
+++ b/lib/helpers/export_helper.dart
@@ -7,11 +7,13 @@ import 'package:path/path.dart' as p;
 import 'package:path_provider/path_provider.dart';
 
 import '../model/device_detail.dart';
+import '../model/overlay.dart';
 import '../model/site.dart';
 import '../utils/polygon_container.dart';
 import 'let_type_helper.dart';
 import 'network_type_helper.dart';
 import 'polygon_helper.dart';
+import 'site_helper.dart';
 import 'telco_helper.dart';
 
 /// Exports the currently drawn signal-coverage polygons (and their on-tower
@@ -66,6 +68,111 @@ class ExportHelper {
     final DateTime now = DateTime.now();
     return '${now.year}${_pad(now.month)}${_pad(now.day)}'
         '_${_pad(now.hour)}${_pad(now.minute)}${_pad(now.second)}';
+  }
+
+  /// Exports every tower currently on the map to a towers GeoJSON file (one point per tower
+  /// carrying its carrier, generation, frequency and device attributes) and a towers CSV file.
+  /// Mirrors the Android app's Export Towers (GeoJSON) / Export Towers (CSV) menu items.
+  /// Returns the list of written file paths (empty if there are no towers on the map).
+  static Future<List<String>> exportTowers() async {
+    // Collect every unique site currently drawn on the map, with its devices.
+    final Map<Site, List<DeviceDetails>> siteDevices = <Site, List<DeviceDetails>>{};
+    for (final MapOverlay overlay in SiteHelper.globalListMapOverlay) {
+      final Site? site = overlay.site;
+      if (site == null) continue;
+      siteDevices.putIfAbsent(site, () => site.getDeviceDetailsMobileBands().values
+          .map((MapEntry<DeviceDetails, bool> e) => e.key)
+          .toList());
+    }
+
+    if (siteDevices.isEmpty) return <String>[];
+
+    final Directory dir = await getApplicationDocumentsDirectory();
+    final String stamp = _timeStamp();
+    final List<String> paths = <String>[];
+
+    // GeoJSON
+    final File geoFile = File(p.join(dir.path, 'AusPhoneTowers_Towers_$stamp.geojson'));
+    await geoFile.writeAsString(_towersToGeoJson(siteDevices), flush: true);
+    paths.add(geoFile.path);
+
+    // CSV
+    final File csvFile = File(p.join(dir.path, 'AusPhoneTowers_Towers_$stamp.csv'));
+    await csvFile.writeAsString(_towersToCsv(siteDevices), flush: true);
+    paths.add(csvFile.path);
+
+    return paths;
+  }
+
+  static Map<String, dynamic> _towerProperties(Site site, DeviceDetails device) {
+    return <String, dynamic>{
+      'name': site.getNameFormatted(),
+      'operatorName': TelcoHelper.getName(site.getTelco()),
+      'siteId': site.siteId,
+      'networkType': NetworkTypeHelper.resolveNetworkToName(device.getNetworkType()),
+      'lteType': LteTypeHelper.getFirstTwoChars(device.getLteType()),
+      'frequency': (device.frequency ?? 0) / 1000 / 1000,
+      'bandwidth': (device.bandwidth ?? 0) / 1000 / 1000,
+      'emission': device.emission ?? '',
+      'eirp': device.eirp,
+      'azimuth': device.azimuth,
+      'towerHeight': device.getTowerHeight(),
+      'latitude': site.getLatLng().latitude,
+      'longitude': site.getLatLng().longitude,
+    };
+  }
+
+  static String _towersToGeoJson(Map<Site, List<DeviceDetails>> siteDevices) {
+    final List<Map<String, dynamic>> features = <Map<String, dynamic>>[];
+    for (final MapEntry<Site, List<DeviceDetails>> entry in siteDevices.entries) {
+      final Site site = entry.key;
+      for (final DeviceDetails device in entry.value) {
+        features.add(<String, dynamic>{
+          'type': 'Feature',
+          'geometry': <String, dynamic>{
+            'type': 'Point',
+            'coordinates': <double>[
+              site.getLatLng().longitude,
+              site.getLatLng().latitude,
+            ],
+          },
+          'properties': _towerProperties(site, device),
+        });
+      }
+    }
+    return JsonEncoder.withIndent('  ').convert(<String, dynamic>{
+      'type': 'FeatureCollection',
+      'features': features,
+    });
+  }
+
+  static String _towersToCsv(Map<Site, List<DeviceDetails>> siteDevices) {
+    final StringBuffer sb = StringBuffer();
+    sb.writeln('name,operatorName,siteId,networkType,lteType,frequency,'
+        'bandwidth,emission,eirp,azimuth,towerHeight,latitude,longitude');
+    for (final MapEntry<Site, List<DeviceDetails>> entry in siteDevices.entries) {
+      final Site site = entry.key;
+      for (final DeviceDetails device in entry.value) {
+        final Map<String, dynamic> props = _towerProperties(site, device);
+        final List<String> values = <String>[
+          '"${(props['name'] as String).replaceAll('"', '""')}"',
+          '"${props['operatorName']}"',
+          '${props['siteId']}',
+          '"${props['networkType']}"',
+          '"${props['lteType']}"',
+          '${props['frequency']}',
+          '${props['bandwidth']}',
+          '"${props['emission']}"',
+          '${props['eirp']}',
+          '${props['azimuth']}',
+          '${props['towerHeight']}',
+          '${props['latitude']}',
+          '${props['longitude']}',
+        ];
+        sb.writeln(values.join(','));
+      }
+    }
+    return sb.toString();
   }
 
   static String _pad(int value) => value.toString().padLeft(2, '0');

--- a/lib/helpers/polygon_helper.dart
+++ b/lib/helpers/polygon_helper.dart
@@ -426,12 +426,22 @@ class PolygonHelper with ChangeNotifier {
       String text, Color color) async {
     final BitmapDescriptor icon = await _createLabelIcon(text, color);
     if (!sitesPolygons.containsKey(site)) return;
-    // Draw a single label at a randomised point on the outermost (furthest) signal
-    // ring. The outer ring is the point furthest from the tower, and the random
-    // bearing stops labels from multiple antennas / neighbouring towers piling up
-    // on top of one another.
-    final int index = (math.Random().nextDouble() * ring.length).floor() % ring.length;
-    final LatLng position = ring[index];
+    // Place the label at the point on the outer signal-strength ring that is *furthest*
+    // from the tower. HRP rings are irregular (terrain, hills), so a random point can land
+    // on the near side of the ring and end up piled up around the site marker. Choosing the
+    // furthest point pushes the label to the outer edge of the coverage polygon, matching the
+    // Android app's behaviour of drawing frequency/technology text away from the tower.
+    final LatLng sitePos = site.getLatLng();
+    int bestIndex = 0;
+    double maxDist = -1;
+    for (int k = 0; k < ring.length; k++) {
+      final double d = _distanceMetres(sitePos, ring[k]);
+      if (d > maxDist) {
+        maxDist = d;
+        bestIndex = k;
+      }
+    }
+    final LatLng position = ring[bestIndex];
     final Marker marker = Marker(
       markerId: MarkerId('label_${device.sddId}'),
       position: position,
@@ -445,6 +455,19 @@ class PolygonHelper with ChangeNotifier {
     // newly added label markers are rendered. Called on the singleton instance because
     // this is a static method.
     PolygonHelper().notifyListeners();
+  }
+
+  /// Great-circle distance (metres) between two coordinates, via the haversine formula.
+  /// Used to find the ring point furthest from the tower when placing text labels.
+  static double _distanceMetres(LatLng a, LatLng b) {
+    const double earthRadius = 6371000.0;
+    final double lat1 = a.latitude * math.pi / 180;
+    final double lat2 = b.latitude * math.pi / 180;
+    final double dLat = (b.latitude - a.latitude) * math.pi / 180;
+    final double dLon = (b.longitude - a.longitude) * math.pi / 180;
+    final double h = math.sin(dLat / 2) * math.sin(dLat / 2) +
+        math.cos(lat1) * math.cos(lat2) * math.sin(dLon / 2) * math.sin(dLon / 2);
+    return 2 * earthRadius * math.asin(math.min(1.0, math.sqrt(h)));
   }
 
   /// Render a small rounded label bitmap for use as a Marker icon.

--- a/lib/helpers/polygon_helper.dart
+++ b/lib/helpers/polygon_helper.dart
@@ -41,6 +41,17 @@ class PolygonHelper with ChangeNotifier {
   static final double BEARING_START = 1.25;
   static final double BEARING_INCREMENT = 2.50;
 
+  /// Polygon rendering precision — the bearing step (in degrees) used when tracing each
+  /// signal-strength band. A smaller step draws more points and a smoother, more accurate
+  /// shape (at the cost of CPU/time); a larger step is faster but blockier. Mirrors the
+  /// Android app's polygon-point-count control. Default 2.5° ≈ 144 points per ring.
+  static double polygonBearingIncrement = BEARING_INCREMENT;
+
+  /// Named precision presets for the Polygon Precision menu.
+  static const double kPolygonPrecisionLow = 5.0; // ~72 points per ring
+  static const double kPolygonPrecisionMedium = 2.5; // ~144 points per ring (default)
+  static const double kPolygonPrecisionHigh = 1.0; // ~360 points per ring
+
   /// Default signal-strength ring drawn on first launch (or before any stored
   /// preference is applied). Indexes into NetworkTypeHelper.getNetworkBars():
   /// 0 = Maximum, 1 = Strong, 2 = Good, 3 = Weak. We default to Strong.
@@ -500,7 +511,7 @@ class PolygonHelper with ChangeNotifier {
     }
     //Log.d("PolygonHelper", "power_dBm="+power_dBm+" freeSpaceLoss_dBi="+freeSpaceLoss_dBi+" towerHeight="+towerHeight);
 
-    for (double bearing = BEARING_START; bearing < 360; bearing += BEARING_INCREMENT) {
+    for (double bearing = BEARING_START; bearing < 360; bearing += polygonBearingIncrement) {
       //TODO calculare Terrain
       Set<HeightDistancePair> heightToDistance = {};
       int hillHeight = 0;

--- a/lib/helpers/polygon_helper.dart
+++ b/lib/helpers/polygon_helper.dart
@@ -426,11 +426,12 @@ class PolygonHelper with ChangeNotifier {
       String text, Color color) async {
     final BitmapDescriptor icon = await _createLabelIcon(text, color);
     if (!sitesPolygons.containsKey(site)) return;
-    // Place the label at the point on the outer signal-strength ring that is *furthest*
-    // from the tower. HRP rings are irregular (terrain, hills), so a random point can land
-    // on the near side of the ring and end up piled up around the site marker. Choosing the
-    // furthest point pushes the label to the outer edge of the coverage polygon, matching the
-    // Android app's behaviour of drawing frequency/technology text away from the tower.
+    // Place the label *outside* the coverage polygon so it does not sit on top of the shaded
+    // area (or the site marker). The polygon grows outward from the tower, so the outer ring
+    // is still inside the fill — we therefore anchor on the point of that ring furthest from
+    // the tower, then push the marker a further margin *outward* (away from the tower) into
+    // clear space. HRP rings are irregular (terrain, hills, sectors), so this keeps labels
+    // clear of the centre instead of piling up on the site.
     final LatLng sitePos = site.getLatLng();
     int bestIndex = 0;
     double maxDist = -1;
@@ -441,7 +442,12 @@ class PolygonHelper with ChangeNotifier {
         bestIndex = k;
       }
     }
-    final LatLng position = ring[bestIndex];
+    final LatLng furthest = ring[bestIndex];
+    // Bearing from the tower out to the furthest ring point; extend ~300 m past it.
+    final double bearing = _bearingDegrees(sitePos, furthest);
+    final LatLng position =
+        GetLicenceHRP.travel(furthest, bearing, kLabelOuterMarginKm);
+
     final Marker marker = Marker(
       markerId: MarkerId('label_${device.sddId}'),
       position: position,
@@ -457,6 +463,10 @@ class PolygonHelper with ChangeNotifier {
     PolygonHelper().notifyListeners();
   }
 
+  /// How far (km) outside the furthest ring point the coverage label is pushed, so it sits in
+  /// clear space rather than on the shaded polygon or the site marker.
+  static const double kLabelOuterMarginKm = 0.3;
+
   /// Great-circle distance (metres) between two coordinates, via the haversine formula.
   /// Used to find the ring point furthest from the tower when placing text labels.
   static double _distanceMetres(LatLng a, LatLng b) {
@@ -468,6 +478,17 @@ class PolygonHelper with ChangeNotifier {
     final double h = math.sin(dLat / 2) * math.sin(dLat / 2) +
         math.cos(lat1) * math.cos(lat2) * math.sin(dLon / 2) * math.sin(dLon / 2);
     return 2 * earthRadius * math.asin(math.min(1.0, math.sqrt(h)));
+  }
+
+  /// Initial bearing (degrees, 0 = north, clockwise) from coordinate [a] to [b].
+  static double _bearingDegrees(LatLng a, LatLng b) {
+    final double lat1 = a.latitude * math.pi / 180;
+    final double lat2 = b.latitude * math.pi / 180;
+    final double dLon = (b.longitude - a.longitude) * math.pi / 180;
+    final double y = math.sin(dLon) * math.cos(lat2);
+    final double x = math.cos(lat1) * math.sin(lat2) -
+        math.sin(lat1) * math.cos(lat2) * math.cos(dLon);
+    return (math.atan2(y, x) * 180 / math.pi + 360) % 360;
   }
 
   /// Render a small rounded label bitmap for use as a Marker icon.

--- a/lib/model/device_detail.dart
+++ b/lib/model/device_detail.dart
@@ -14,6 +14,13 @@ import 'package:phonetowers/utils/app_constants.dart';
 import 'client.dart';
 
 class DeviceDetails {
+  // Frequency refarming (accuracy-preserving re-expression of legacy 2G/3G licences as their
+  // current 4G/5G reuse). Mirrors the Android app's SiteHelper.refarmEnabled: true by default,
+  // "Disable frequency refarming" in the Hiding Menu sets it to false to show the literal licence
+  // type. This only changes how 2G/3G-era licences are labelled — genuine 4G/5G carriers are
+  // unaffected either way.
+  static bool refarmEnabled = true;
+
   // Details from the database
 
   String? sddId,
@@ -233,6 +240,85 @@ class DeviceDetails {
       default:
         return [NetworkType.UNKNOWN];
     }
+  }
+
+  /// Rank of a network generation, used to pick the newest genuine capability when a licence row
+  /// authorises more than one technology (keeps the map to one transmitter per licence).
+  static int generationRank(NetworkType nt) {
+    switch (nt) {
+      case NetworkType.NR:
+        return 5;
+      case NetworkType.LTE:
+      case NetworkType.NB_IOT:
+        return 4;
+      case NetworkType.UMTS:
+        return 3;
+      case NetworkType.GSM:
+        return 2;
+      case NetworkType.OTHER:
+        return 1;
+      default:
+        return 0; // UNKNOWN
+    }
+  }
+
+  /// Bands historically licensed for 2G/3G that Australia now operates as 4G/5G (3G fully
+  /// decommissioned: Optus Apr-2024, Telstra Oct-2024, Vodafone/TPG Jan-2025). A carrier in one of
+  /// these bands is, in real-world utilisation, 4G/5G — not the legacy 2G/3G the emission implies.
+  static bool isRefarmedLteBand(int frequency) {
+    return (frequency >= 700000000 && frequency < 800000000) // B28 700 MHz
+        ||
+        (frequency >= 820000000 && frequency < 1000000000) // B5/B8 850/900 MHz
+        ||
+        (frequency >= 1700000000 && frequency < 2200000000) // B3/B1 1800/2100 MHz
+        ||
+        (frequency >= 2300000000 && frequency < 2700000000); // B40/B7 2300/2600 MHz
+  }
+
+  /// Frequency-refarming rule (accuracy-preserving, not hiding): a licence whose only classification
+  /// is legacy 3G (UMTS), sitting in a band Australia now runs as 4G/5G, is re-expressed with its
+  /// current reuse (LTE). This reflects what is actually broadcasting rather than the decommissioned
+  /// original. Genuine 2G (GSM) emissions and any licence already carrying an explicit LTE/NR/NB_IOT
+  /// classification are left untouched.
+  static List<NetworkType> applyRefarm(List<NetworkType> types, int frequency) {
+    if (!isRefarmedLteBand(frequency)) {
+      return types;
+    }
+    bool hasModern = false;
+    bool hasUmts = false;
+    for (final NetworkType nt in types) {
+      if (nt == NetworkType.LTE || nt == NetworkType.NR || nt == NetworkType.NB_IOT) {
+        hasModern = true;
+      }
+      if (nt == NetworkType.UMTS) {
+        hasUmts = true;
+      }
+    }
+    if (hasModern || !hasUmts) {
+      // Already modern, or not an exclusively-3G licence in a refarmed band — leave as-is.
+      return types;
+    }
+    // Exclusively 3G UMTS in a refarmed band: re-express at its current 4G reuse.
+    return <NetworkType>[NetworkType.LTE];
+  }
+
+  /// Returns the single network type for one ACMA licence row, derived from the row's own emission
+  /// designator + frequency band. Frequency refarming is applied on top when [refarmEnabled] is
+  /// true (the default). When refarming is off the literal licence type (e.g. 3G UMTS) is shown.
+  static NetworkType getNetworkTypeForLicence(
+      String? emission, int frequency, int bandwidth, Telco telco, int antennaId) {
+    List<NetworkType> types =
+        getNetworkTypeStatic(emission, frequency, bandwidth, telco, antennaId);
+    if (refarmEnabled) {
+      types = applyRefarm(types, frequency);
+    }
+    NetworkType best = NetworkType.UNKNOWN;
+    for (final NetworkType nt in types) {
+      if (generationRank(nt) > generationRank(best)) {
+        best = nt;
+      }
+    }
+    return best;
   }
 
   LteType getLteType() {

--- a/lib/restful/get_devices.dart
+++ b/lib/restful/get_devices.dart
@@ -66,8 +66,9 @@ class GetDevices {
       double eirp = values.eirp != null ? double.tryParse(values.eirp!.value) ?? 0.0 : 0.0;
       int antennaId = values.antennaId != null ? int.tryParse(values.antennaId!.value) ?? 0 : 0;
 
-      for (NetworkType networkType
-          in DeviceDetails.getNetworkTypeStatic(emission, frequency, bandwidth, telco, antennaId)) {
+      for (NetworkType networkType in <NetworkType>[
+        DeviceDetails.getNetworkTypeForLicence(emission, frequency, bandwidth, telco, antennaId)
+      ]) {
         //Prepare device details
         DeviceDetails device = DeviceDetails(
           sddId: values.sddId!.value,

--- a/lib/ui/map_common.dart
+++ b/lib/ui/map_common.dart
@@ -250,6 +250,12 @@ class MapBodyState extends AbstractMapBodyState {
   /// ******************** State variables ************************************
   late GoogleMapController mapController;
   Location _locationService = new Location();
+
+  // Follow GPS (drive mode): keeps the map centred on the device's location. Mirrors the
+  // Android app's "Follow GPS" toolbar action.
+  static bool followGPS = false;
+  static StreamSubscription<LocationData>? _followGpsSubscription;
+  static MapBodyState? currentInstance;
   late SharedPreferences prefs;
   final TextEditingController _searchTextFilter = new TextEditingController();
   bool isShowCancelSearch = false;
@@ -265,6 +271,7 @@ class MapBodyState extends AbstractMapBodyState {
   @override
   void initState() {
     super.initState();
+    currentInstance = this;
 
     if (!kIsWeb) {
       PurchaseHelper().initStoreInfo(showSnackBar: showSnackbar);
@@ -783,6 +790,47 @@ class MapBodyState extends AbstractMapBodyState {
     //      logger.d('after 2 second delay');
     //      askForLocationPermission();
     //    });
+  }
+
+  /// Toggle Follow GPS (drive mode). When enabled, the camera is recentred on the device's
+  /// location as it moves. Mirrors the Android app's "Follow GPS" toolbar action.
+  static Future<void> toggleFollowGPS() async {
+    final MapBodyState? state = currentInstance;
+    if (state == null) return;
+    followGPS = !followGPS;
+    if (followGPS) {
+      PermissionStatus permission = await state._locationService.requestPermission();
+      if (permission != PermissionStatus.granted) {
+        followGPS = false;
+        state.showSnackbar(
+            message: 'Cannot activate Follow GPS because location permission was not granted!',
+            isDismissible: true);
+        return;
+      }
+      if (!await state._locationService.serviceEnabled()) {
+        await state._locationService.requestService();
+      }
+      _followGpsSubscription = state._locationService.onLocationChanged.listen((LocationData location) {
+        if (!followGPS) return;
+        state.mapController.moveCamera(
+          CameraUpdate.newCameraPosition(
+            CameraPosition(
+                target: LatLng(location.latitude!, location.longitude!),
+                zoom: (state.lastCameraPosition?.zoom ?? kDefaultZoom)),
+          ),
+        );
+      });
+      state.showSnackbar(
+          message:
+              'GPS is now ON. This mode uses battery faster and keeps the screen centred on your location while you move!');
+    } else {
+      await _followGpsSubscription?.cancel();
+      _followGpsSubscription = null;
+      state.showSnackbar(
+          message:
+              'GPS is now OFF. This will save battery and stop the screen from recentring on your location!');
+    }
+    state.setState(() {});
   }
 
   Future askForLocationPermission() async {

--- a/lib/ui/widgets/option_menu.dart
+++ b/lib/ui/widgets/option_menu.dart
@@ -5,6 +5,7 @@ import 'package:logger/logger.dart';
 import 'package:phonetowers/helpers/export_helper.dart';
 import 'package:phonetowers/helpers/map_helper.dart';
 import 'package:phonetowers/helpers/polygon_helper.dart';
+import 'package:phonetowers/ui/map_common.dart';
 import 'package:phonetowers/helpers/purchase_helper.dart';
 import 'package:phonetowers/helpers/search_helper.dart';
 import 'package:phonetowers/helpers/site_helper.dart';
@@ -14,12 +15,34 @@ import 'package:phonetowers/utils/strings.dart';
 import 'package:phonetowers/utils/utils.dart';
 import 'package:provider/provider.dart';
 import 'package:shared_preferences/shared_preferences.dart';
+import 'package:phonetowers/model/device_detail.dart';
 
 typedef void ShowSnackBar({
   required String message,
   Duration duration,
   bool isDismissible,
 });
+
+/// Top-level option-menu items, ordered to mirror the Android app's popup menu
+/// (Reload Everything, Follow GPS, Hide Borders, Search, Map Mode, Hiding Menu,
+/// Export Data, Polygon Precision, Remove Ads, Donate, Problems Menu, Rate App, Close App).
+/// Using an enum (rather than an index into a list) guarantees the label shown always
+/// maps to the correct behaviour — fixing the old "labels don't match the action" bug.
+enum OptionMenuItem {
+  reloadEverything,
+  followGPS,
+  hideBorders,
+  searchSites,
+  mapMode,
+  hidingMenu,
+  exportData,
+  polygonPrecision,
+  removeAds,
+  donate,
+  problemsMenu,
+  rateApp,
+  closeApp,
+}
 
 class OptionsMenu extends StatefulWidget {
   final ShowSnackBar showSnackBar;
@@ -48,92 +71,128 @@ class _OptionsMenuState extends State<OptionsMenu> {
 
   void _loadSharedPreference() async {
     prefs = await SharedPreferences.getInstance();
+    // Restore persisted preference-driven toggles.
+    DeviceDetails.refarmEnabled =
+        prefs.getBool(SharedPreferencesHelper.krefarmEnabled) ?? true;
+    final int precisionIndex = SharedPreferencesHelper.getInt(
+        key: SharedPreferencesHelper.kpolygonPrecision, prefs: prefs);
+    PolygonHelper.polygonBearingIncrement = _precisionIncrement(precisionIndex);
+  }
+
+  static double _precisionIncrement(int index) {
+    switch (index) {
+      case 0:
+        return PolygonHelper.kPolygonPrecisionLow;
+      case 2:
+        return PolygonHelper.kPolygonPrecisionHigh;
+      default:
+        return PolygonHelper.kPolygonPrecisionMedium;
+    }
+  }
+
+  static int _precisionIndex(double increment) {
+    if ((increment - PolygonHelper.kPolygonPrecisionLow).abs() < 1e-9) return 0;
+    if ((increment - PolygonHelper.kPolygonPrecisionHigh).abs() < 1e-9) return 2;
+    return 1;
   }
 
   @override
   Widget build(BuildContext context) {
     return Consumer<PurchaseHelper>(
-      builder: (context, purchaseHelper, child) => PopupMenuButton<OptionItem>(
+      builder: (context, purchaseHelper, child) => PopupMenuButton<OptionMenuItem>(
         icon: Icon(Icons.more_vert),
         itemBuilder: (BuildContext context) {
-          return listOptionItem
-              .map<PopupMenuItem<OptionItem>>((OptionItem optionItem) {
-            return PopupMenuItem<OptionItem>(
-              value: optionItem,
+          return OptionMenuItem.values
+              .where((OptionMenuItem item) {
+                // Donations are not available on the Web build (no App Store purchases).
+                if (item == OptionMenuItem.donate) return !kIsWeb;
+                return true;
+              })
+              .map<PopupMenuItem<OptionMenuItem>>((OptionMenuItem item) {
+            return PopupMenuItem<OptionMenuItem>(
+              value: item,
               child: Row(
                 mainAxisAlignment: MainAxisAlignment.spaceBetween,
                 children: <Widget>[
-                  Text(optionItem.title),
-                  if (optionItem.trailing) ...[
+                  Text(_topLevelTitle(item)),
+                  if (_hasSubmenu(item)) ...[
+                    Icon(Icons.play_arrow, color: Colors.black54, size: 12)
+                  ] else if (item == OptionMenuItem.hideBorders ||
+                      item == OptionMenuItem.followGPS) ...[
                     Icon(
-                      Icons.play_arrow,
+                      item == OptionMenuItem.hideBorders
+                          ? (PolygonHelper.showPolygonBorders
+                              ? Icons.check_box_outline_blank
+                              : Icons.check_box)
+                          : (MapBodyState.followGPS
+                              ? Icons.check_box
+                              : Icons.check_box_outline_blank),
                       color: Colors.black54,
-                      size: 12,
+                      size: 14,
                     )
                   ]
                 ],
               ),
             );
-          }).where((optionItem) {
-            int optionItemPosition = listOptionItem.indexOf(optionItem.value!);
-            if (optionItemPosition == 1) {
-              return !SearchHelper.calculatingSearchResults;
-            } else if (optionItemPosition == 6) {
-              // Only show donations on non-web platforms
-              return !kIsWeb;
-            } else {
-              return true;
-            }
           }).toList();
         },
-        onSelected: (optionItem) async {
-          int selectedOptionItem = listOptionItem.indexOf(optionItem);
-          switch (selectedOptionItem) {
-            case 0: //Show / Hide border
-              {
-                PolygonHelper.showPolygonBorders =
-                    !PolygonHelper.showPolygonBorders;
-                optionItem.title = PolygonHelper.showPolygonBorders
-                    ? Strings.hide_border
-                    : Strings.show_border;
-                widget.showSnackBar(
-                    message:
-                        '${PolygonHelper.showPolygonBorders ? 'Showing' : 'Hiding'} polygon radiation borders!');
-                //Make UI changes
-                Provider.of<PolygonHelper>(context, listen: false)
-                    .refreshPolygons(true);
-                //Saving in shared pref
-                SharedPreferencesHelper.saveBoolean(
-                    key: SharedPreferencesHelper.kshowPolygonBorders,
-                    value: PolygonHelper.showPolygonBorders,
-                    prefs: prefs);
-                break;
-              }
-            case 1: //Search sites
-              {
-                logger.d('search sites');
-                Provider.of<SearchHelper>(context, listen: false)
-                    .setSearchStatus(true);
-                break;
-              }
-            case 2: //Clear everything
+        onSelected: (OptionMenuItem item) async {
+          switch (item) {
+            case OptionMenuItem.reloadEverything:
               {
                 SiteHelper().clearMap(
                     onCameraMoveFromLastLocation:
                         widget.onCameraMoveFromLastLocation);
                 break;
               }
-            case 3: //Map mode
+            case OptionMenuItem.followGPS:
+              {
+                await MapBodyState.toggleFollowGPS();
+                break;
+              }
+            case OptionMenuItem.hideBorders:
+              {
+                PolygonHelper.showPolygonBorders = !PolygonHelper.showPolygonBorders;
+                widget.showSnackBar(
+                    message:
+                        '${PolygonHelper.showPolygonBorders ? 'Showing' : 'Hiding'} polygon radiation borders!');
+                Provider.of<PolygonHelper>(context, listen: false)
+                    .refreshPolygons(true);
+                SharedPreferencesHelper.saveBoolean(
+                    key: SharedPreferencesHelper.kshowPolygonBorders,
+                    value: PolygonHelper.showPolygonBorders,
+                    prefs: prefs);
+                setState(() {});
+                break;
+              }
+            case OptionMenuItem.searchSites:
+              {
+                logger.d('search sites');
+                Provider.of<SearchHelper>(context, listen: false)
+                    .setSearchStatus(true);
+                break;
+              }
+            case OptionMenuItem.mapMode:
               {
                 showRadioOptionMenu();
                 break;
               }
-            case 4: //Hiding menu
+            case OptionMenuItem.hidingMenu:
               {
-                showSingleRowOptionMenu(listHidingMenuItem, kHidingMenu);
+                showHidingMenu();
                 break;
               }
-            case 5: //Remove ads
+            case OptionMenuItem.exportData:
+              {
+                showExportMenu();
+                break;
+              }
+            case OptionMenuItem.polygonPrecision:
+              {
+                showPolygonPrecisionMenu();
+                break;
+              }
+            case OptionMenuItem.removeAds:
               {
                 listRemoveAdsItem.elementAt(2)
                   ..title =
@@ -152,7 +211,7 @@ class _OptionsMenuState extends State<OptionsMenu> {
                 showSingleRowOptionMenu(listRemoveAdsItem, kRemoveAds);
                 break;
               }
-            case 6: //Donate
+            case OptionMenuItem.donate:
               {
                 listDonateItem.elementAt(2)
                   ..isEnabled = !purchaseHelper.isDonateSmallPurchased;
@@ -163,58 +222,245 @@ class _OptionsMenuState extends State<OptionsMenu> {
                 showSingleRowOptionMenu(listDonateItem, kDonate);
                 break;
               }
-            case 7: //Developer or Regular mode
+            case OptionMenuItem.problemsMenu:
               {
-                MapHelper().developerMode = !MapHelper().developerMode;
-                optionItem.title = MapHelper().developerMode
-                    ? Strings.regularMode
-                    : Strings.developerMode;
-                MapHelper().toggleDeveloperMode();
-                PolygonHelper().refreshPolygons(false);
+                showProblemsMenu();
                 break;
               }
-            case 8: //Report problem
+            case OptionMenuItem.rateApp:
               {
-                widget.takeScreenshot();
+                final InAppReview inAppReview = InAppReview.instance;
+                if (await inAppReview.isAvailable()) {
+                  inAppReview.requestReview();
+                } else {
+                  Utils.launchURL(
+                      'https://apps.apple.com/us/app/aus-phone-towers-3g-4g-5g/id1488594332');
+                }
                 break;
               }
-            case 9: //Source code
+            case OptionMenuItem.closeApp:
               {
-                showSingleRowOptionMenu(listLinksItem, kLinks);
-                break;
-              }
-            case 10: //User Guide
-              {
-                Utils.launchURL(kUserGuideUrl);
-                break;
-              }
-            case 11: //Export coverage
-              {
+                // iOS (and Web) do not permit an app to programmatically exit, so we just
+                // inform the user. On Android the equivalent menu item fully exits the app.
                 widget.showSnackBar(
-                    message: 'Exporting coverage polygons...');
-                ExportHelper.exportSignalPolygons().then((List<String> paths) {
-                  if (paths.isEmpty) {
-                    widget.showSnackBar(
-                        message:
-                            'There are no signal polygons on the map to export. Tap a tower to draw its coverage first...');
-                  } else {
-                    final StringBuffer message = StringBuffer();
-                    message.write(
-                        'Exported ${paths.length} files to the app documents folder:\n');
-                    for (final String path in paths) {
-                      message.write('$path\n');
-                    }
-                    widget.showSnackBar(
-                        message: message.toString(),
-                        duration: const Duration(seconds: 10));
-                  }
-                });
+                    message:
+                        'Close App is not available on this platform — use the device '
+                        'switcher / home button to leave the app.');
                 break;
               }
           }
         },
       ),
     );
+  }
+
+  String _topLevelTitle(OptionMenuItem item) {
+    switch (item) {
+      case OptionMenuItem.reloadEverything:
+        return Strings.reload_everything;
+      case OptionMenuItem.followGPS:
+        return MapBodyState.followGPS ? Strings.follow_gps_on : Strings.follow_gps_off;
+      case OptionMenuItem.hideBorders:
+        return PolygonHelper.showPolygonBorders ? Strings.hide_border : Strings.show_border;
+      case OptionMenuItem.searchSites:
+        return Strings.search_sites;
+      case OptionMenuItem.mapMode:
+        return Strings.map_mode;
+      case OptionMenuItem.hidingMenu:
+        return Strings.hiding_menu;
+      case OptionMenuItem.exportData:
+        return Strings.export_data;
+      case OptionMenuItem.polygonPrecision:
+        return Strings.polygon_precision;
+      case OptionMenuItem.removeAds:
+        return Strings.remove_ads;
+      case OptionMenuItem.donate:
+        return Strings.donate;
+      case OptionMenuItem.problemsMenu:
+        return Strings.problems_menu;
+      case OptionMenuItem.rateApp:
+        return Strings.rateApp;
+      case OptionMenuItem.closeApp:
+        return Strings.closeApp;
+    }
+  }
+
+  bool _hasSubmenu(OptionMenuItem item) =>
+      item == OptionMenuItem.mapMode ||
+      item == OptionMenuItem.hidingMenu ||
+      item == OptionMenuItem.exportData ||
+      item == OptionMenuItem.polygonPrecision ||
+      item == OptionMenuItem.problemsMenu;
+
+  // ----- Hiding Menu (mirrors Android: Hide Radiation on Click + Disable frequency refarming) -----
+  Future showHidingMenu() async {
+    final SingleRowItem hideRadiation = SingleRowItem(
+      title: PolygonHelper.drawPolygonsOnClick
+          ? Strings.hiding_menu_hide_radiation
+          : Strings.hiding_menu_draw_radiation,
+      isEnabled: true,
+    );
+    final SingleRowItem disableRefarm = SingleRowItem(
+      title: Strings.disable_refarming,
+      isEnabled: true,
+      isChecked: !DeviceDetails.refarmEnabled,
+    );
+    final List<SingleRowItem> items = <SingleRowItem>[
+      SingleRowItem(isTitle: true, title: Strings.hiding_menu, isEnabled: false),
+      hideRadiation,
+      disableRefarm,
+    ];
+    final SingleRowItem? chosen = await showSingleRowOptionMenu(items, kHidingMenu);
+    if (chosen == null) return;
+    if (chosen == hideRadiation) {
+      PolygonHelper.drawPolygonsOnClick = !PolygonHelper.drawPolygonsOnClick;
+      SharedPreferencesHelper.saveBoolean(
+          key: SharedPreferencesHelper.kdrawPolygonsOnClick,
+          value: PolygonHelper.drawPolygonsOnClick,
+          prefs: prefs);
+      if (!PolygonHelper.drawPolygonsOnClick) {
+        PolygonHelper().clearSitePatterns(false);
+      }
+      setState(() {});
+    } else if (chosen == disableRefarm) {
+      DeviceDetails.refarmEnabled = !DeviceDetails.refarmEnabled;
+      SharedPreferencesHelper.saveBoolean(
+          key: SharedPreferencesHelper.krefarmEnabled,
+          value: DeviceDetails.refarmEnabled,
+          prefs: prefs);
+      // Re-classify licences: reload sites + polygons with the new refarm setting.
+      SiteHelper().clearMap(
+          onCameraMoveFromLastLocation: widget.onCameraMoveFromLastLocation);
+      setState(() {});
+      widget.showSnackBar(
+          message: DeviceDetails.refarmEnabled
+              ? 'Refarming on: legacy 3G licences in 4G/5G bands shown at their current reuse (4G LTE).'
+              : 'Refarming off: showing the literal licence type (e.g. 3G UMTS).');
+    }
+  }
+
+  // ----- Export Data (mirrors Android: Export Towers GeoJSON/CSV + Export Coverage GeoJSON) -----
+  Future showExportMenu() async {
+    final List<SingleRowItem> items = <SingleRowItem>[
+      SingleRowItem(isTitle: true, title: Strings.export_data, isEnabled: false),
+      SingleRowItem(title: Strings.export_towers_geojson, isEnabled: true),
+      SingleRowItem(title: Strings.export_towers_csv, isEnabled: true),
+      SingleRowItem(title: Strings.export_coverage_geojson, isEnabled: true),
+    ];
+    final SingleRowItem? chosen = await showSingleRowOptionMenu(items, kExportMenu);
+    if (chosen == null) return;
+    if (chosen.title == Strings.export_towers_geojson ||
+        chosen.title == Strings.export_towers_csv) {
+      widget.showSnackBar(message: 'Exporting towers...');
+      ExportHelper.exportTowers().then((List<String> paths) {
+        _reportExport(paths, 'towers');
+      });
+    } else if (chosen.title == Strings.export_coverage_geojson) {
+      widget.showSnackBar(message: 'Exporting coverage polygons...');
+      ExportHelper.exportSignalPolygons().then((List<String> paths) {
+        _reportExport(paths, 'coverage polygons');
+      });
+    }
+  }
+
+  void _reportExport(List<String> paths, String what) {
+    if (paths.isEmpty) {
+      widget.showSnackBar(
+          message:
+              'There are no $what on the map to export. Load some towers${what == "coverage polygons" ? " and tap one to draw its coverage" : ""} first...');
+    } else {
+      final StringBuffer message = StringBuffer();
+      message.write('Exported ${paths.length} files to the app documents folder:\n');
+      for (final String path in paths) {
+        message.write('$path\n');
+      }
+      widget.showSnackBar(message: message.toString(), duration: const Duration(seconds: 10));
+    }
+  }
+
+  // ----- Polygon Precision (number of points per ring) -----
+  Future showPolygonPrecisionMenu() async {
+    final int current = _OptionsMenuState._precisionIndex(PolygonHelper.polygonBearingIncrement);
+    final List<SingleRowItem> items = <SingleRowItem>[
+      SingleRowItem(isTitle: true, title: Strings.polygon_precision, isEnabled: false),
+      SingleRowItem(
+          title: Strings.polygon_precision_low,
+          isEnabled: true,
+          isChecked: current == 0),
+      SingleRowItem(
+          title: Strings.polygon_precision_medium,
+          isEnabled: true,
+          isChecked: current == 1),
+      SingleRowItem(
+          title: Strings.polygon_precision_high,
+          isEnabled: true,
+          isChecked: current == 2),
+    ];
+    final SingleRowItem? chosen = await showSingleRowOptionMenu(items, kPolygonPrecision);
+    if (chosen == null) return;
+    int index;
+    if (chosen.title == Strings.polygon_precision_low) {
+      index = 0;
+    } else if (chosen.title == Strings.polygon_precision_high) {
+      index = 2;
+    } else {
+      index = 1;
+    }
+    PolygonHelper.polygonBearingIncrement = _precisionIncrement(index);
+    SharedPreferencesHelper.setInt(
+        key: SharedPreferencesHelper.kpolygonPrecision, value: index, prefs: prefs);
+    setState(() {});
+    widget.showSnackBar(
+        message: 'Polygon precision set to ${_topLevelPrecisionLabel(index)}. '
+            'Newly drawn coverage will use this.');
+  }
+
+  String _topLevelPrecisionLabel(int index) {
+    switch (index) {
+      case 0:
+        return 'Low';
+      case 2:
+        return 'High';
+      default:
+        return 'Medium';
+    }
+  }
+
+  // ----- Problems Menu (mirrors Android: Developer Mode, User Guide, Report Problem,
+  //      plus the Links items — AusPhoneTowers.com.au, iOS App Store, Source Code) -----
+  Future showProblemsMenu() async {
+    final List<SingleRowItem> items = <SingleRowItem>[
+      SingleRowItem(isTitle: true, title: Strings.problems_menu, isEnabled: false),
+      SingleRowItem(
+          title: MapHelper().developerMode ? Strings.regularMode : Strings.developerMode,
+          isEnabled: true),
+      SingleRowItem(title: Strings.userGuide, isEnabled: true),
+      SingleRowItem(title: Strings.reportProblem, isEnabled: true),
+      SingleRowItem(isTitle: true, title: Strings.links, isEnabled: false),
+      SingleRowItem(title: Strings.ausphonetowers, isEnabled: true),
+      SingleRowItem(title: Strings.iosAppStore, isEnabled: true),
+      SingleRowItem(title: Strings.sourceCode, isEnabled: true),
+    ];
+    final SingleRowItem? chosen = await showSingleRowOptionMenu(items, kProblemsMenu);
+    if (chosen == null) return;
+    if (chosen.title == Strings.userGuide) {
+      Utils.launchURL(kUserGuideUrl);
+    } else if (chosen.title == Strings.reportProblem) {
+      widget.takeScreenshot();
+    } else if (chosen.title == Strings.ausphonetowers) {
+      Utils.launchURL('https://ausphonetowers.com.au/');
+    } else if (chosen.title == Strings.iosAppStore) {
+      Utils.launchURL(
+          'https://apps.apple.com/us/app/aus-phone-towers-3g-4g-5g/id1488594332');
+    } else if (chosen.title == Strings.sourceCode) {
+      Utils.launchURL(
+          'https://github.com/bradrushworth/aus_phone_towers_iphone');
+    } else {
+      MapHelper().developerMode = !MapHelper().developerMode;
+      MapHelper().toggleDeveloperMode();
+      PolygonHelper().refreshPolygons(false);
+      setState(() {});
+    }
   }
 
   Future showSingleRowOptionMenu(
@@ -237,6 +483,10 @@ class _OptionsMenuState extends State<OptionsMenu> {
                 ),
               ] else ...[
                 if (singleRowItem.prefix != null) ...[singleRowItem.prefix!],
+                if (singleRowItem.isChecked) ...[
+                  Icon(Icons.check_box, color: Colors.black54, size: 14),
+                  SizedBox(width: 8),
+                ],
                 Expanded(
                   child: Padding(
                     padding: EdgeInsets.only(
@@ -288,32 +538,6 @@ class _OptionsMenuState extends State<OptionsMenu> {
       //     }
       //     break;
       //   }
-      case kHidingMenu: //Hiding menu
-        {
-          switch (selectedOptionItem) {
-            case 1: //Hide/ Show radiation on click
-              {
-                PolygonHelper.drawPolygonsOnClick =
-                    !PolygonHelper.drawPolygonsOnClick;
-                singleRowItem.title = PolygonHelper.drawPolygonsOnClick
-                    ? Strings.hiding_menu_hide_radiation
-                    : Strings.hiding_menu_draw_radiation;
-                setState(() {});
-                if (!PolygonHelper.drawPolygonsOnClick) {
-                  PolygonHelper().clearSitePatterns(false);
-                  SiteHelper().clearPolygons();
-                  //disableFollowGPS(); TODO
-                }
-                //Saving in shared pref
-                SharedPreferencesHelper.saveBoolean(
-                    key: SharedPreferencesHelper.kdrawPolygonsOnClick,
-                    value: PolygonHelper.drawPolygonsOnClick,
-                    prefs: prefs);
-                break;
-              }
-          }
-          break;
-        }
       case kRemoveAds:
         {
           switch (selectedOptionItem) {
@@ -356,43 +580,6 @@ class _OptionsMenuState extends State<OptionsMenu> {
               {
                 PurchaseHelper()
                     .initiatePurchase(sku: PurchaseHelper.SKU_DONATION_LARGE);
-                break;
-              }
-          }
-          break;
-        }
-      case kLinks:
-        {
-          switch (selectedOptionItem) {
-            case 1: //Rate App TODO Not relevant for web!
-              {
-                final InAppReview inAppReview = InAppReview.instance;
-
-                if (await inAppReview.isAvailable()) {
-                  inAppReview.requestReview();
-                }
-
-                // This package also has in app review, but it should not be used on a direct button tab.
-                // inAppReview.openStoreListing(appStoreId: kAppleId
-
-                break;
-              }
-
-            case 2: //AusPhoneTowers.com.au
-              {
-                Utils.launchURL('https://ausphonetowers.com.au/');
-                break;
-              }
-            case 3: //iOS App Store
-              {
-                Utils.launchURL(
-                    'https://apps.apple.com/us/app/aus-phone-towers-3g-4g-5g/id1488594332');
-                break;
-              }
-            case 4: //Source Code
-              {
-                Utils.launchURL(
-                    'https://github.com/bradrushworth/aus_phone_towers_iphone');
                 break;
               }
           }
@@ -445,43 +632,21 @@ class _OptionsMenuState extends State<OptionsMenu> {
 }
 
 //********************** All options ***************************//
-class OptionItem {
-  OptionItem({required this.title, this.trailing = false});
-
-  String title;
-  final bool trailing;
-}
-
-List<OptionItem> listOptionItem = <OptionItem>[
-  OptionItem(
-      title: PolygonHelper.showPolygonBorders
-          ? Strings.hide_border
-          : Strings.show_border),
-  OptionItem(title: Strings.search_sites),
-  OptionItem(title: Strings.reload_everything),
-  OptionItem(title: Strings.map_mode, trailing: true),
-  OptionItem(title: Strings.hiding_menu, trailing: true),
-  OptionItem(title: Strings.remove_ads, trailing: true),
-  OptionItem(title: Strings.donate, trailing: true),
-  OptionItem(
-      title: MapHelper().developerMode
-          ? Strings.regularMode
-          : Strings.developerMode),
-  OptionItem(title: Strings.reportProblem),
-  OptionItem(title: Strings.userGuide),
-  OptionItem(title: Strings.links, trailing: true),
-  OptionItem(title: Strings.exportPolygons),
-];
 
 //********************** Clear map ***************************//
 class SingleRowItem {
   SingleRowItem(
-      {this.isTitle = false, required this.title, this.prefix, this.isEnabled = true});
+      {this.isTitle = false,
+      required this.title,
+      this.prefix,
+      this.isEnabled = true,
+      this.isChecked = false});
 
   bool isTitle;
   String title;
   final Widget? prefix;
   bool isEnabled;
+  bool isChecked;
 }
 
 // List<SingleRowItem> listClearMapItem = <SingleRowItem>[
@@ -490,14 +655,6 @@ class SingleRowItem {
 //   SingleRowItem(
 //       title: Strings.reload_everything, prefix: Icon(Icons.delete_forever))
 // ];
-
-List<SingleRowItem> listHidingMenuItem = <SingleRowItem>[
-  SingleRowItem(isTitle: true, title: Strings.hiding_menu, isEnabled: false),
-  SingleRowItem(
-      title: PolygonHelper.drawPolygonsOnClick
-          ? Strings.hiding_menu_hide_radiation
-          : Strings.hiding_menu_draw_radiation),
-];
 
 List<SingleRowItem> listRemoveAdsItem = <SingleRowItem>[
   SingleRowItem(isTitle: true, title: Strings.remove_ads, isEnabled: true),
@@ -532,14 +689,6 @@ List<SingleRowItem> listDonateItem = <SingleRowItem>[
   SingleRowItem(
       title: Strings.donateLarge,
       isEnabled: !PurchaseHelper().isDonateLargePurchased),
-];
-
-List<SingleRowItem> listLinksItem = <SingleRowItem>[
-  SingleRowItem(isTitle: true, title: Strings.links),
-  SingleRowItem(title: Strings.rateApp),
-  SingleRowItem(title: Strings.ausphonetowers),
-  SingleRowItem(title: Strings.iosAppStore),
-  SingleRowItem(title: Strings.sourceCode),
 ];
 
 //********************** Radio options ***************************//

--- a/lib/utils/app_constants.dart
+++ b/lib/utils/app_constants.dart
@@ -32,6 +32,9 @@ const int kHidingMenu = 2;
 const int kRemoveAds = 3;
 const int kDonate = 4;
 const int kLinks = 5;
+const int kExportMenu = 6;
+const int kPolygonPrecision = 7;
+const int kProblemsMenu = 8;
 
 const String kAppleId = '1488594332';
 

--- a/lib/utils/shared_pref_helper.dart
+++ b/lib/utils/shared_pref_helper.dart
@@ -44,6 +44,9 @@ class SharedPreferencesHelper {
   static final String kMapMode = 'mapMode';
   static final String kdrawPolygonsOnClick = 'drawPolygonsOnClick';
   static final String kcalculateTerrain = 'calculateTerrain';
+  static final String krefarmEnabled = 'refarmEnabled';
+  static final String kpolygonPrecision = 'polygonPrecision';
+  static final String kfollowGPS = 'followGPS';
 
   static final String betaLaunchPopup = 'betaLaunchPopup';
 

--- a/lib/utils/strings.dart
+++ b/lib/utils/strings.dart
@@ -56,6 +56,9 @@ class Strings {
   static String transmitter_type_aviation = 'Aviation';
 
   static String calculate_terrain = 'Calculate Terrain';
+  static String follow_gps = 'Follow GPS';
+  static String follow_gps_on = 'Disable Follow GPS';
+  static String follow_gps_off = 'Follow GPS';
   static String hide_border = 'Hide Borders';
   static String show_border = 'Show Borders';
   static String search_sites = 'Search Sites';
@@ -72,6 +75,21 @@ class Strings {
   static String hiding_menu = 'Hiding Menu';
   static String hiding_menu_hide_radiation = 'Hide Radiation on Click';
   static String hiding_menu_draw_radiation = 'Draw Radiation on Click';
+  static String disable_refarming = 'Disable frequency refarming';
+  static String disable_refarming_summary =
+      'When on, legacy 3G (UMTS) licences in bands now run as 4G/5G are shown at their current reuse (4G LTE).';
+
+  static String polygon_precision = 'Polygon Precision';
+  static String polygon_precision_low = 'Low (faster)';
+  static String polygon_precision_medium = 'Medium';
+  static String polygon_precision_high = 'High (smoother)';
+
+  static String export_data = 'Export Data';
+  static String export_towers_geojson = 'Export Towers (GeoJSON)';
+  static String export_towers_csv = 'Export Towers (CSV)';
+  static String export_coverage_geojson = 'Export Coverage (GeoJSON)';
+
+  static String problems_menu = 'Problems Menu';
 
   static String remove_ads = 'Remove Ads';
   static String remove_ads_subscribe_previous =

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -12,7 +12,7 @@ publish_to: 'none'
 # In iOS, build-name is used as CFBundleShortVersionString while build-number used as CFBundleVersion.
 # Read more about iOS versioning at
 # https://developer.apple.com/library/archive/documentation/General/Reference/InfoPlistKeyReference/Articles/CoreFoundationKeys.html
-version: 1.11.5+110
+version: 1.11.6+111
 
 environment:
   sdk: '>=3.9.2 <4.0.0'


### PR DESCRIPTION
## Summary

Ports applicable features from the Android Java app into the iPhone Flutter app, fixes the broken options menu (User Guide label/behaviour mismatch), fixes polygon coverage-label placement, and updates documentation. Release version bump to `1.11.6+111`.

This PR was created by an AI agent (OpenHands) on behalf of @bradrushworth.

## Menu regrouping + User Guide fix (`lib/ui/widgets/option_menu.dart`)
- Rewrote the right-hand options menu to mirror the Android app's grouped structure using an **enum-based `OptionMenuItem`** instead of the old index-into-a-list approach. This is the core fix: labels can no longer drift from their behaviour (the original bug where "User Guide" opened the wrong page).
- New top-level order: Reload Everything, **Follow GPS**, Show/Hide Borders, Search Sites, Map Mode, **Hiding Menu**, **Export Data**, **Polygon Precision**, Remove Ads, Donate, **Problems Menu**, Rate App, Close App.
- Submenus: Hiding Menu (Hide Radiation on Click + **Disable frequency refarming**), Export Data (Export Towers GeoJSON/CSV + Export Coverage), Polygon Precision, Problems Menu (Developer Mode, **User Guide**, Report Problem, Links).

## Frequency refarming (`lib/model/device_detail.dart`, `lib/restful/get_devices.dart`)
- Added `refarmEnabled` flag + `generationRank`, `isRefarmedLteBand`, `applyRefarm`, `getNetworkTypeForLicence` (mirrors Android `SiteHelper`/`DeviceDetails`). Wired `getNetworkTypeForLicence` into `get_devices.dart` so legacy 3G licences in refarmed bands are re-classified as 4G LTE by default, toggleable via the Hiding Menu.

## Polygon precision (`lib/helpers/polygon_helper.dart`)
- Added `polygonBearingIncrement` (Low 5°, Medium 2.5°, High 1°) controlling points per ring, used by `createBasicPolygon`. Exposed in the new Polygon Precision submenu and persisted.

## Follow GPS (`lib/ui/map_common.dart`)
- Added `MapBodyState.toggleFollowGPS()` "drive mode" that recentres the map on the device location via a location stream.

## Export Towers (`lib/helpers/export_helper.dart`)
- Added `exportTowers()` producing towers GeoJSON + CSV for every tower currently on the map, alongside the existing coverage export.

## Polygon coverage-label placement (`lib/helpers/polygon_helper.dart`)
- Coverage frequency/technology labels were bunching up around the centre site marker. Root cause: the label was placed at a **random index** on the outer ring, which (because HRP rings are irregular) frequently landed on the near side of the ring.
- Fix: anchor on the point of the outermost ring that is **furthest** from the tower, then **push the label a further 300 m outward** (along the bearing from the site to that point) into clear space *beyond* the coverage polygon. Added `_distanceMetres()` (haversine) and `_bearingDegrees()` helpers.

## Documentation (`docs/USER_GUIDE.md`)
- Updated Section 3 to describe the new menu accurately.
- Updated the Differences table to mark Follow GPS, refarming, polygon precision, and tower export as now available.
- Added a **Coverage labels** bullet explaining label placement.

## Verification
- `flutter analyze`: no errors.
- `flutter test test/pathloss/ test/device_details_test.dart`: all **86 tests pass**.

## Notes
- Did not push to `main` directly; this PR is the release path. Version bumped to `1.11.6+111` (Codemagic build will trigger on merge).
- One consideration: the 300 m label margin is fixed. If it looks too small at country-wide zoom, it can be made a fraction of the furthest distance instead — happy to follow up.