### PR TITLE
Align CityDensity thresholds with Android app's calibrated values (#13)

### DIFF
--- a/lib/model/site.dart
+++ b/lib/model/site.dart
@@ -282,9 +282,12 @@ class Site {
   // How populated is the containing geohash with sites?
   // Geohash length of SiteHelper.GEOHASH_LENGTH is currently 5.
   static CityDensity getCityDensityStatic(int numSitesInGeohash) {
-    if (numSitesInGeohash >= 50) return CityDensity.METRO;
-    if (numSitesInGeohash >= 30) return CityDensity.URBAN;
-    if (numSitesInGeohash >=  5) return CityDensity.SUBURBAN;
+    // Calibrated against real Australian CBD site counts (per-telco per geohash-5 cell):
+    // Sydney/Melbourne CBDs reach 150+; Perth/Adelaide/Brisbane/Canberra 25-149;
+    // residential/outer-suburban 4-24; rural 0-3. Matches the Android app's thresholds.
+    if (numSitesInGeohash >= 150) return CityDensity.METRO;
+    if (numSitesInGeohash >= 25) return CityDensity.URBAN;
+    if (numSitesInGeohash >=  4) return CityDensity.SUBURBAN;
     return CityDensity.OPEN;
   }
 

--- a/test/site_test.dart
+++ b/test/site_test.dart
@@ -181,6 +181,27 @@ void main() {
       expect(site.getIconName(), 'telstra.png');
     });
 
+    // City-density bands calibrated 2026-08-13 against the four Okumura-Hata / COST-231-Hata
+    // environment classes that AnalyticPathLossModel implements (each a distinct real-world building
+    // environment: METRO=large-city/urban canyons, URBAN=city fabric, SUBURBAN=residential,
+    // OPEN=rural). Mirrors SiteTest#getCityDensityThresholds in the Android sibling app.
+    test('getCityDensityThresholds', () {
+      // OPEN: sparse / rural (0-3 sites per telco per geohash-5 cell)
+      expect(Site.getCityDensityStatic(0), CityDensity.OPEN);
+      expect(Site.getCityDensityStatic(1), CityDensity.OPEN);
+      expect(Site.getCityDensityStatic(3), CityDensity.OPEN);
+      // SUBURBAN: 4-24 sites (residential suburban homes)
+      expect(Site.getCityDensityStatic(4), CityDensity.SUBURBAN);
+      expect(Site.getCityDensityStatic(24), CityDensity.SUBURBAN);
+      // URBAN: 25-149 sites (Okumura-Hata urban; inner-city ring, major hubs, smaller capitals)
+      expect(Site.getCityDensityStatic(25), CityDensity.URBAN);
+      expect(Site.getCityDensityStatic(149), CityDensity.URBAN);
+      // METRO: 150+ sites (COST-231-Hata large city, Tokyo-density cores)
+      expect(Site.getCityDensityStatic(150), CityDensity.METRO);
+      expect(Site.getCityDensityStatic(250), CityDensity.METRO);
+      expect(Site.getCityDensityStatic(1000), CityDensity.METRO);
+    });
+
     //   test('getActiveDevicesForArfcnLTE', () {
     //     int CONNECTED_NETWORK_TYPE = 13;
     //     NetworkType networkType = CellIdentity.getNetworkGeneration(


### PR DESCRIPTION
## Summary

Fixes #13.

Aligns the `CityDensity` classification thresholds in `lib/model/site.dart` with the Android app's calibrated values.

The iPhone app used uncalibrated thresholds (50/30/5) for classifying city density from per-telco site counts per geohash-5 cell. The Android app (`Site.java`) explicitly calibrated these against real Australian CBD measurements:

| Density | iPhone (old) | Android (calibrated) |
|---|---|---|
| METRO | ≥ 50 | ≥ 150 |
| URBAN | ≥ 30 | ≥ 25 |
| SUBURBAN | ≥ 5 | ≥ 4 |
| OPEN | < 5 | < 4 |

This mismatch caused some areas to be classified as METRO when they should be URBAN, changing which Hata/COST-231 formula was used and thus producing inaccurate propagation distances — the original complaint in #13.

## Verification
- `flutter analyze`: no errors.

This PR was created by an AI agent (OpenHands) on behalf of @bradrushworth.