### PR TITLE
Increase coverage polygon visibility on all map types (#23)

### DIFF
--- a/docs/USER_GUIDE.md
+++ b/docs/USER_GUIDE.md
@@ -17,7 +17,8 @@ datasets and draws each transmitter on a Google Map together with its estimated 
   generic non‑telco icon). Tap a marker for details.
 - **Coverage polygons** — coloured shaded areas showing the estimated coverage of each antenna.
   The colour matches the carrier (see the legend below). Toggle the outline with **Show/Hide
-  Borders**.
+  Borders**. Polygon opacity is boosted on satellite/hybrid map types and when **Follow GPS**
+  (drive mode) is active, so coverage remains visible over dark imagery.
 - **Coverage labels** — each tower's coverage carries a small text label showing its
   **frequency and technology** (e.g. `850 MHz 4G LTE`). The label is placed *outside* the shaded
   polygon — anchored on the point of the outermost ring that is furthest from the tower, then pushed

--- a/lib/helpers/map_helper.dart
+++ b/lib/helpers/map_helper.dart
@@ -24,6 +24,10 @@ class MapHelper with ChangeNotifier {
   bool developerMode = false;
   Logger logger = new Logger();
 
+  /// Whether follow-GPS (drive mode) is active. Static so polygon_helper can
+  /// boost polygon opacity when the user is driving, matching the Android app.
+  static bool followGPS = false;
+
   void setMapMode(int mode, SharedPreferences prefs) {
     mapMode = mode;
     SharedPreferencesHelper.setInt(

--- a/lib/helpers/polygon_helper.dart
+++ b/lib/helpers/polygon_helper.dart
@@ -280,10 +280,10 @@ class PolygonHelper with ChangeNotifier {
       Telco telco = site.getTelco();
       int alpha = 50;
       if (TelcoHelper.isTelecommunications(telco)) {
-        alpha = 10;
-//                if (CustomLocationListener.followGPS) {
-//                  alpha += 10;//TODO custom location listener
-//                }
+        alpha = 20;
+        if (MapHelper.followGPS) {
+          alpha += 20;
+        }
         alpha += (math.log(1 + (capacity / (1000 * 1000))) * 2).toInt();
       }
 
@@ -291,7 +291,7 @@ class PolygonHelper with ChangeNotifier {
         case 2:
         case 3:
           {
-            alpha += 25;
+            alpha += 40;
           }
           break;
       }

--- a/lib/ui/map_common.dart
+++ b/lib/ui/map_common.dart
@@ -253,7 +253,7 @@ class MapBodyState extends AbstractMapBodyState {
 
   // Follow GPS (drive mode): keeps the map centred on the device's location. Mirrors the
   // Android app's "Follow GPS" toolbar action.
-  static bool followGPS = false;
+
   static StreamSubscription<LocationData>? _followGpsSubscription;
   static MapBodyState? currentInstance;
   late SharedPreferences prefs;
@@ -797,11 +797,11 @@ class MapBodyState extends AbstractMapBodyState {
   static Future<void> toggleFollowGPS() async {
     final MapBodyState? state = currentInstance;
     if (state == null) return;
-    followGPS = !followGPS;
-    if (followGPS) {
+    MapHelper.followGPS = !MapHelper.followGPS;
+    if (MapHelper.followGPS) {
       PermissionStatus permission = await state._locationService.requestPermission();
       if (permission != PermissionStatus.granted) {
-        followGPS = false;
+        MapHelper.followGPS = false;
         state.showSnackbar(
             message: 'Cannot activate Follow GPS because location permission was not granted!',
             isDismissible: true);
@@ -811,7 +811,7 @@ class MapBodyState extends AbstractMapBodyState {
         await state._locationService.requestService();
       }
       _followGpsSubscription = state._locationService.onLocationChanged.listen((LocationData location) {
-        if (!followGPS) return;
+        if (!MapHelper.followGPS) return;
         state.mapController.moveCamera(
           CameraUpdate.newCameraPosition(
             CameraPosition(

--- a/lib/ui/widgets/option_menu.dart
+++ b/lib/ui/widgets/option_menu.dart
@@ -124,7 +124,7 @@ class _OptionsMenuState extends State<OptionsMenu> {
                           ? (PolygonHelper.showPolygonBorders
                               ? Icons.check_box_outline_blank
                               : Icons.check_box)
-                          : (MapBodyState.followGPS
+                          : (MapHelper.followGPS
                               ? Icons.check_box
                               : Icons.check_box_outline_blank),
                       color: Colors.black54,
@@ -259,7 +259,7 @@ class _OptionsMenuState extends State<OptionsMenu> {
       case OptionMenuItem.reloadEverything:
         return Strings.reload_everything;
       case OptionMenuItem.followGPS:
-        return MapBodyState.followGPS ? Strings.follow_gps_on : Strings.follow_gps_off;
+        return MapHelper.followGPS ? Strings.follow_gps_on : Strings.follow_gps_off;
       case OptionMenuItem.hideBorders:
         return PolygonHelper.showPolygonBorders ? Strings.hide_border : Strings.show_border;
       case OptionMenuItem.searchSites:


### PR DESCRIPTION
## Summary

Fixes #23 (split from #15).

Telstra and Optus coverage patterns were difficult to see, especially on satellite/hybrid map types. This PR increases polygon opacity:

| Setting | Old | New |
|---|---|---|
| Base telecom alpha | 10 | 20 |
| Satellite/hybrid boost | +25 | +40 |
| Follow GPS boost | commented out | +20 (wired up) |

The followGPS boost now matches the Android app's behaviour (`alpha += 20` when `CustomLocationListener.followGPS`). To enable `polygon_helper.dart` to read the followGPS state, the field was moved from `MapBodyState` to `MapHelper` (which is already imported by polygon_helper).

## Verification
- `flutter analyze`: no errors.

This PR was created by an AI agent (OpenHands) on behalf of @bradrushworth.