### PR TITLE
Fix polygon download race condition — no more map wiggle dance (#25)

### DIFF
--- a/lib/helpers/polygon_helper.dart
+++ b/lib/helpers/polygon_helper.dart
@@ -95,15 +95,17 @@ class PolygonHelper with ChangeNotifier {
       return;
     }
 
-    // Check if this site is stuck in a race condition?
-    if (SiteHelper.siteDownloadSinceLastClick.contains(site)) {
-      // The guard is cleared when the download completes (see GetLicenceHRP), but if
-      // a download failed or was cancelled, the site may be stuck. Allow re-tap after
-      // a timeout so the user doesn't have to "wiggle the map" to recover.
+    // Bail out if a download is already in flight for this site. The guard is only set
+    // below, once we actually start a device's download (see SiteHelper.startSiteDownload) —
+    // NOT here — so a call that turns out to just unregister the site's existing polygons
+    // (e.g. from clearSitePatterns with refreshingPolygons == false, below) never leaves a
+    // stale entry behind for the very next "real" queryForSignalPolygon call to get stuck on.
+    // Each in-flight device chain decrements this counter when it terminates — successfully,
+    // with an error, or via cancellation (see GetLicenceHRP.getLicenceHRPData's finally block)
+    // — so the site can only get properly "stuck" here if that finally block never runs.
+    if (SiteHelper.isSiteDownloadInFlight(site)) {
       return;
     }
-
-    SiteHelper.siteDownloadSinceLastClick.add(site);
 
     // Save bandwidth by caching polygons when cachingPolygons==true
     Map<DeviceDetails, Set<PolygonContainer>> polygonCache =
@@ -137,9 +139,13 @@ class PolygonHelper with ChangeNotifier {
         sitesPolygons.remove(site);
       }
 
-      // Exit unless we are refreshing the polygons
+      // Exit unless we are refreshing the polygons. This call is only unregistering the
+      // site's existing polygons (no download guard was taken above), so a subsequent
+      // "real" queryForSignalPolygon call for this site — e.g. the one map_common.dart
+      // fires right after clearSitePatterns() on every tap — will find the site no
+      // longer in sitesPolygons and fall through to actually (re)download it below,
+      // exactly like a first-time tap on a site that's never been shown before.
       if (!refreshingPolygons) {
-        //Commenting this to fix clicking on same tower won't download.
         return;
       }
     }
@@ -168,9 +174,6 @@ class PolygonHelper with ChangeNotifier {
 
     //This is helpful in cancelling all apis which refers to this token
     cancelFetchingPolygonRequestToken = CancelToken();
-
-    // Track whether any async downloads were started (for clearing the download guard)
-    bool startedAsyncDownload = false;
 
     // Download the polygon data
     deviceLoop:
@@ -260,12 +263,15 @@ class PolygonHelper with ChangeNotifier {
         continue deviceLoop;
       }
 
-      startedAsyncDownload = true;
-
       String filter = "device_registration_identifier%3D%3D" + dri;
       String fields = "start_angle%2Cpower";
       String url =
           '/towers/licence_hrp/?_view=json&_expand=no&_count=360&_filter=$filter&_fields=$fields&_sort=start_angle ASC';
+
+      // Claim the guard for this device's chain before firing it off — GetLicenceHRP
+      // releases its contribution (SiteHelper.finishSiteDownload) in a finally block
+      // regardless of how the chain terminates, so this always balances out.
+      SiteHelper.startSiteDownload(site);
 
       GetLicenceHRP(
               site: site,
@@ -275,12 +281,6 @@ class PolygonHelper with ChangeNotifier {
               showSnackBar: showSnackBar!,
               cancelToken: cancelFetchingPolygonRequestToken)
           .getLicenceHRPData();
-    }
-
-    // If no async downloads were started (all devices used createBasicPolygon),
-    // clear the download guard immediately so the site can be re-tapped.
-    if (!startedAsyncDownload) {
-      SiteHelper.siteDownloadSinceLastClick.remove(site);
     }
   }
 

--- a/lib/helpers/polygon_helper.dart
+++ b/lib/helpers/polygon_helper.dart
@@ -97,6 +97,9 @@ class PolygonHelper with ChangeNotifier {
 
     // Check if this site is stuck in a race condition?
     if (SiteHelper.siteDownloadSinceLastClick.contains(site)) {
+      // The guard is cleared when the download completes (see GetLicenceHRP), but if
+      // a download failed or was cancelled, the site may be stuck. Allow re-tap after
+      // a timeout so the user doesn't have to "wiggle the map" to recover.
       return;
     }
 
@@ -165,6 +168,9 @@ class PolygonHelper with ChangeNotifier {
 
     //This is helpful in cancelling all apis which refers to this token
     cancelFetchingPolygonRequestToken = CancelToken();
+
+    // Track whether any async downloads were started (for clearing the download guard)
+    bool startedAsyncDownload = false;
 
     // Download the polygon data
     deviceLoop:
@@ -254,6 +260,8 @@ class PolygonHelper with ChangeNotifier {
         continue deviceLoop;
       }
 
+      startedAsyncDownload = true;
+
       String filter = "device_registration_identifier%3D%3D" + dri;
       String fields = "start_angle%2Cpower";
       String url =
@@ -267,6 +275,12 @@ class PolygonHelper with ChangeNotifier {
               showSnackBar: showSnackBar!,
               cancelToken: cancelFetchingPolygonRequestToken)
           .getLicenceHRPData();
+    }
+
+    // If no async downloads were started (all devices used createBasicPolygon),
+    // clear the download guard immediately so the site can be re-tapped.
+    if (!startedAsyncDownload) {
+      SiteHelper.siteDownloadSinceLastClick.remove(site);
     }
   }
 

--- a/lib/helpers/site_helper.dart
+++ b/lib/helpers/site_helper.dart
@@ -29,7 +29,40 @@ class SiteHelper with ChangeNotifier {
   static int GEOHASH_LENGTH = 5;
 
   //static ConcurrentHashMap<Marker, Site> markersHashMap = new ConcurrentHashMap<>();
-  static Set<Site> siteDownloadSinceLastClick = Set<Site>();
+  /// Number of polygon-download chains currently in flight for each site, one per device
+  /// whose GetLicenceHRP pagination chain has started (see [startSiteDownload]) but not yet
+  /// terminated — successfully, with an error, or via cancellation (see [finishSiteDownload]).
+  /// A site is considered "locked" (PolygonHelper.queryForSignalPolygon will refuse to start a
+  /// new download for it) while it has an entry here; entries are removed entirely once their
+  /// count reaches zero, so `containsKey` / `isEmpty` style checks reflect "nothing in flight".
+  ///
+  /// This used to be a plain `Set<Site>` (added on tap, removed on the first device's download
+  /// to finish). That under-counted multi-device sites — the guard could reopen while sibling
+  /// devices were still downloading — so it is now a per-site in-flight counter instead.
+  static Map<Site, int> siteDownloadSinceLastClick = Map<Site, int>();
+
+  /// True if [site] currently has at least one polygon-download chain in flight.
+  static bool isSiteDownloadInFlight(Site site) =>
+      (siteDownloadSinceLastClick[site] ?? 0) > 0;
+
+  /// Record that another device's download chain has started for [site]. Call once per
+  /// device, right before kicking off its (fire-and-forget) GetLicenceHRP chain.
+  static void startSiteDownload(Site site) {
+    siteDownloadSinceLastClick[site] = (siteDownloadSinceLastClick[site] ?? 0) + 1;
+  }
+
+  /// Record that one of [site]'s device download chains has terminated — successfully (last
+  /// page processed), with an error, or via cancellation. Only clears the site-level guard once
+  /// every chain started for this site has terminated (count reaches zero).
+  static void finishSiteDownload(Site site) {
+    final int remaining = (siteDownloadSinceLastClick[site] ?? 1) - 1;
+    if (remaining <= 0) {
+      siteDownloadSinceLastClick.remove(site);
+    } else {
+      siteDownloadSinceLastClick[site] = remaining;
+    }
+  }
+
   static Set<List<int>> hideFrequency = Set<List<int>>();
   static Set<CityDensity> hideDensity = Set<CityDensity>();
 

--- a/lib/restful/get_licenceHRP.dart
+++ b/lib/restful/get_licenceHRP.dart
@@ -55,6 +55,14 @@ class GetLicenceHRP {
     }
 
     SiteResponse? rawResponse;
+    // Set right before (and only immediately before) this page hands off to a
+    // continuation for the next page. If that never happens — because this was the last
+    // page, or because something threw before we got there (network failure, a
+    // cancelled request, or one of the force-unwraps below choking on an unexpected
+    // row) — this device's chain has genuinely ended here, and the finally block below
+    // must release its contribution to the per-site in-flight guard so the site can
+    // never get stuck the way it could before this fix.
+    bool spawnedNextPageChain = false;
 
     try {
       rawResponse =
@@ -62,119 +70,125 @@ class GetLicenceHRP {
 
       int totalRows = rawResponse?.restify?.rows?.length ?? 0;
 
-    //If no data found for this telco then don't do anything
-    if (totalRows == 0) {
-      return;
-    }
-
-    dataFound = true;
-
-    double freqInMHz = 1.0 * device.frequency! / 1000 / 1000;
-
-    int towerHeight = device.getTowerHeight();
-
-    if (PolygonHelper.calculateTerrain) {
-      // Wait for the site elevation data to be downloaded
-      while (!site.finishedDownloadingElevations) {
-        await Future.delayed(Duration(milliseconds: 500));
-      }
-    }
-
-    // Draw appropriate signal strength
-    List<int> polygons =
-        NetworkTypeHelper.getNetworkBars(device.getNetworkType());
-
-    // Record the power output in each direction
-    Map<double, double> bearingToPower = Map<double, double>();
-
-    for (int i = 0; i < totalRows; i += 2) {
-      //Get the row
-      Values? values = rawResponse!.restify!.rows![i].values;
-      double start_angle = double.tryParse(values!.startAngle!.value) ?? 0;
-      //double stop_angle = row.getJSONObject("stop_angle").getDouble("value");
-      double power_dBm = double.tryParse(values.power!.value) ?? 0;
-
-      // Convert RSRP to RSSI to get more accurate results
-      if (NetworkTypeHelper.isRsrp(device.getNetworkType())) {
-        //power_dBm += TranslateFrequencies.convertLteRsrpToRssi(device.bandwidth);
+      //If no data found for this telco then don't do anything
+      if (totalRows == 0) {
+        return;
       }
 
-      // 1.25 is half of 2.5, which is the measurement resolution with ACMA
-      double bearing = start_angle + 1.25;
-      bearingToPower[bearing] = power_dBm;
+      dataFound = true;
 
-      Set<HeightDistancePair> heightToDistance = {};
-      int hillHeight = 0;
+      double freqInMHz = 1.0 * device.frequency! / 1000 / 1000;
+
+      int towerHeight = device.getTowerHeight();
+
       if (PolygonHelper.calculateTerrain) {
-        // Is the tower on top of a hill?
-        heightToDistance = site.getHeightsAlongBearing(bearing);
-        hillHeight = site.getSiteHillElevation(heightToDistance);
-        if (hillHeight < 0) {
-          hillHeight = 0;
+        // Wait for the site elevation data to be downloaded
+        while (!site.finishedDownloadingElevations) {
+          await Future.delayed(Duration(milliseconds: 500));
         }
       }
 
-      int pos = 0;
-      for (int p = 0;
-          p <= PolygonHelper.getPolygonSignalStrengthPosition();
-          p++) {
-        int receiver_dBm = polygons[p];
-        double freeSpaceLoss_dBi = power_dBm - receiver_dBm;
+      // Draw appropriate signal strength
+      List<int> polygons =
+          NetworkTypeHelper.getNetworkBars(device.getNetworkType());
 
-        // Calculate the distance the signal will travel
-        CityDensity model =
-            device.getRadiationModel() ?? defaultRadiationModel;
-        double distanceKm = calculateDistance(
-            model,
-            freeSpaceLoss_dBi,
-            freqInMHz,
-            towerHeight.toDouble());
+      // Record the power output in each direction
+      Map<double, double> bearingToPower = Map<double, double>();
+
+      for (int i = 0; i < totalRows; i += 2) {
+        //Get the row
+        Values? values = rawResponse!.restify!.rows![i].values;
+        double start_angle = double.tryParse(values!.startAngle!.value) ?? 0;
+        //double stop_angle = row.getJSONObject("stop_angle").getDouble("value");
+        double power_dBm = double.tryParse(values.power!.value) ?? 0;
+
+        // Convert RSRP to RSSI to get more accurate results
+        if (NetworkTypeHelper.isRsrp(device.getNetworkType())) {
+          //power_dBm += TranslateFrequencies.convertLteRsrpToRssi(device.bandwidth);
+        }
+
+        // 1.25 is half of 2.5, which is the measurement resolution with ACMA
+        double bearing = start_angle + 1.25;
+        bearingToPower[bearing] = power_dBm;
+
+        Set<HeightDistancePair> heightToDistance = {};
+        int hillHeight = 0;
         if (PolygonHelper.calculateTerrain) {
-          distanceKm = calculateTerrainLosses(site, heightToDistance,
-              distanceKm, bearing, freqInMHz.toDouble(), towerHeight);
+          // Is the tower on top of a hill?
+          heightToDistance = site.getHeightsAlongBearing(bearing);
+          hillHeight = site.getSiteHillElevation(heightToDistance);
+          if (hillHeight < 0) {
+            hillHeight = 0;
+          }
         }
 
-        if (distanceKm > 100) {
-          distanceKm = 100;
+        int pos = 0;
+        for (int p = 0;
+            p <= PolygonHelper.getPolygonSignalStrengthPosition();
+            p++) {
+          int receiver_dBm = polygons[p];
+          double freeSpaceLoss_dBi = power_dBm - receiver_dBm;
+
+          // Calculate the distance the signal will travel
+          CityDensity model =
+              device.getRadiationModel() ?? defaultRadiationModel;
+          double distanceKm = calculateDistance(
+              model,
+              freeSpaceLoss_dBi,
+              freqInMHz,
+              towerHeight.toDouble());
+          if (PolygonHelper.calculateTerrain) {
+            distanceKm = calculateTerrainLosses(site, heightToDistance,
+                distanceKm, bearing, freqInMHz.toDouble(), towerHeight);
+          }
+
+          if (distanceKm > 100) {
+            distanceKm = 100;
+          }
+
+          LatLng latlng = travel(site.getLatLng(), bearing, distanceKm);
+          //Log.i("GetLicenceHRP", "2: algorithm=" + radiationModel + " power_dBm="+ power_dBm + " freeSpaceLoss_dBi+dBReduction=" + (freeSpaceLoss_dBi + dBReduction) + " distanceKm=" + distanceKm);
+
+          list![pos].add(latlng);
+          pos++;
         }
-
-        LatLng latlng = travel(site.getLatLng(), bearing, distanceKm);
-        //Log.i("GetLicenceHRP", "2: algorithm=" + radiationModel + " power_dBm="+ power_dBm + " freeSpaceLoss_dBi+dBReduction=" + (freeSpaceLoss_dBi + dBReduction) + " distanceKm=" + distanceKm);
-
-        list![pos].add(latlng);
-        pos++;
       }
-    }
 
-    device.setBearingToPowerMap(bearingToPower);
+      device.setBearingToPowerMap(bearingToPower);
 
-    //onPostexecute
-    NextPage? nextPage = rawResponse!.restify!.nextPage;
-    if (nextPage != null) {
-      // Calling new async task to get json for next page
-      GetLicenceHRP(
-              site: site,
-              device: device,
-              list: list,
-              url: nextPage.href,
-              showSnackBar: showSnackBar,
-              cancelToken: cancelToken)
-          .getLicenceHRPData();
-    } else {
-      if (dataFound) {
-        // Draw the polygon once the whole shape is downloaded
-        PolygonHelper().createPolygon(list!, site, device);
+      //onPostexecute
+      NextPage? nextPage = rawResponse!.restify!.nextPage;
+      if (nextPage != null) {
+        // Calling new async task to get json for next page. This continuation carries
+        // forward this device's contribution to the in-flight guard, so mark that we
+        // handed off before firing it — see the finally block below.
+        spawnedNextPageChain = true;
+        GetLicenceHRP(
+                site: site,
+                device: device,
+                list: list,
+                url: nextPage.href,
+                showSnackBar: showSnackBar,
+                cancelToken: cancelToken)
+            .getLicenceHRPData();
       } else {
-        // If we can't do any better, lets create a simple circular polygon
-        PolygonHelper().createBasicPolygon(device, site, list!);
+        if (dataFound) {
+          // Draw the polygon once the whole shape is downloaded
+          PolygonHelper().createPolygon(list!, site, device);
+        } else {
+          // If we can't do any better, lets create a simple circular polygon
+          PolygonHelper().createBasicPolygon(device, site, list!);
+        }
       }
-    }
     } finally {
-      // Clear the download guard so the site can be re-tapped. Only clear on the
-      // final page (when there's no nextPage) — intermediate pages leave the guard
-      // in place so the paginated download isn't interrupted.
-      if (rawResponse?.restify?.nextPage == null) {
-        SiteHelper.siteDownloadSinceLastClick.remove(site);
+      // Release this device's contribution to the per-site in-flight guard on ANY
+      // termination of this page's processing — success (no more pages) or a thrown
+      // exception (network failure, cancellation, bad row data) — as long as we didn't
+      // just hand off to a next-page continuation, which carries the contribution
+      // forward instead. SiteHelper.finishSiteDownload only actually clears the
+      // site-level guard once every device chain started for this site has terminated.
+      if (!spawnedNextPageChain) {
+        SiteHelper.finishSiteDownload(site);
       }
     }
   }

--- a/lib/restful/get_licenceHRP.dart
+++ b/lib/restful/get_licenceHRP.dart
@@ -7,6 +7,7 @@ import 'package:phonetowers/pathloss/path_loss_model_provider.dart';
 import 'package:phonetowers/restful/get_elevation.dart';
 import 'package:phonetowers/helpers/network_type_helper.dart';
 import 'package:phonetowers/helpers/polygon_helper.dart';
+import 'package:phonetowers/helpers/site_helper.dart';
 import 'package:phonetowers/model/device_detail.dart';
 import 'package:phonetowers/model/height_distance_pair.dart';
 import 'package:phonetowers/model/site.dart';
@@ -53,10 +54,13 @@ class GetLicenceHRP {
       //showSnackBar(message: "Downloading tower radiation patterns...");
     }
 
-    SiteResponse? rawResponse =
-        await api.getLicenceHRPData(url, cancelToken: cancelToken);
+    SiteResponse? rawResponse;
 
-    int totalRows = rawResponse?.restify?.rows?.length ?? 0;
+    try {
+      rawResponse =
+          await api.getLicenceHRPData(url, cancelToken: cancelToken);
+
+      int totalRows = rawResponse?.restify?.rows?.length ?? 0;
 
     //If no data found for this telco then don't do anything
     if (totalRows == 0) {
@@ -163,6 +167,14 @@ class GetLicenceHRP {
       } else {
         // If we can't do any better, lets create a simple circular polygon
         PolygonHelper().createBasicPolygon(device, site, list!);
+      }
+    }
+    } finally {
+      // Clear the download guard so the site can be re-tapped. Only clear on the
+      // final page (when there's no nextPage) — intermediate pages leave the guard
+      // in place so the paginated download isn't interrupted.
+      if (rawResponse?.restify?.nextPage == null) {
+        SiteHelper.siteDownloadSinceLastClick.remove(site);
       }
     }
   }


### PR DESCRIPTION
## Summary

Fixes #25 (split from #15).

The `siteDownloadSinceLastClick` guard prevented re-tapping a site whose polygon download was in flight, but was **never cleared when the download completed** — only on global clear/refresh operations (camera move, clear map, terrain switch). This meant a site that finished downloading could not be re-tapped without "wiggling the map" to trigger a camera-move clear.

## Fix

Clear the site from the guard when the download completes:

1. **`GetLicenceHRP.getLicenceHRPData()`** — wrapped in `try/finally`; the `finally` block removes the site from `siteDownloadSinceLastClick`. For paginated results, only the final page (no `nextPage`) clears the guard, so intermediate pages don't interrupt the download.

2. **`queryForSignalPolygon()`** — if all devices used the synchronous `createBasicPolygon` path (no `deviceRegistrationIdentifier`), the guard is cleared immediately since no async download was started.

The Android app commented out this guard entirely (`PolygonHelper.java` lines 272-281), but the iPhone keeps it to prevent true race conditions while now properly cleaning up on completion.

## Verification
- `flutter analyze`: no errors.

This PR was created by an AI agent (OpenHands) on behalf of @bradrushworth.