### PR TITLE
Multi-Tower Coverage + Lock Map (#27)

### DIFF
--- a/docs/USER_GUIDE.md
+++ b/docs/USER_GUIDE.md
@@ -51,8 +51,10 @@ The menu is grouped the same way as the Android app:
 - **Reload Everything** — clear the map and re‑download all towers for the current area.
 - **Follow GPS** — toggle "drive mode". When on, the map stays centred on your location as you
   move (uses more battery). When off, the map stops recentring.
-- **Lock / Unlock Map** — freeze (or unfreeze) pan, zoom, rotate and tilt gestures. Useful when
-  you want to screenshot or study a fixed area of coverage.
+- **Lock / Unlock Map** — freeze (or unfreeze) *all* camera movement: pan, zoom, rotate and tilt
+  gestures, the built‑in "my location" button, Follow GPS's auto‑recentring, and Search's
+  jump‑to‑result. Useful when you want to screenshot or study a fixed area of coverage without
+  anything nudging the camera.
 - **Show / Hide Borders** — toggle the radiation polygon outlines.
 - **Search Sites** — find a specific tower / site.
 - **Map Mode** — Terrain / Hybrid / Satellite / Normal base map.

--- a/docs/USER_GUIDE.md
+++ b/docs/USER_GUIDE.md
@@ -51,6 +51,8 @@ The menu is grouped the same way as the Android app:
 - **Reload Everything** — clear the map and re‑download all towers for the current area.
 - **Follow GPS** — toggle "drive mode". When on, the map stays centred on your location as you
   move (uses more battery). When off, the map stops recentring.
+- **Lock / Unlock Map** — freeze (or unfreeze) pan, zoom, rotate and tilt gestures. Useful when
+  you want to screenshot or study a fixed area of coverage.
 - **Show / Hide Borders** — toggle the radiation polygon outlines.
 - **Search Sites** — find a specific tower / site.
 - **Map Mode** — Terrain / Hybrid / Satellite / Normal base map.
@@ -60,6 +62,9 @@ The menu is grouped the same way as the Android app:
   - **Disable frequency refarming** — when ticked, legacy 3G (UMTS) licences that now run as 4G/5G
     (e.g. band‑refarmed 900/2100 MHz) are shown at their *literal* licence type (3G UMTS) instead
     of being re‑classified to their current reuse (4G LTE). Changing this reloads the towers.
+  - **Multi‑Tower Coverage** — when ticked, tapping additional towers *adds* their coverage
+    polygons to the map instead of replacing the previous tower's coverage. Turn it off (and tap
+    any tower) to clear all accumulated coverage.
 - **Export Data** — a sub‑menu:
   - **Export Towers (GeoJSON)** — one point per tower (carrier, generation, frequency, azimuth,
     height, EIRP, …) for every tower currently on the map.

--- a/lib/helpers/polygon_helper.dart
+++ b/lib/helpers/polygon_helper.dart
@@ -71,6 +71,9 @@ class PolygonHelper with ChangeNotifier {
       new Map<Site, Map<DeviceDetails, Set<PolygonContainer>>>();
   static late Map<Site, Map<DeviceDetails, Set<PolygonContainer>>> sitesPolygonsOppositeTerrain;
   static bool drawPolygonsOnClick = true;
+  // When true, tapping a tower does NOT clear existing polygons, so multiple
+  // towers' coverage can be shown together. Requested in issue #27.
+  static bool multiTowerCoverage = false;
   static Logger logger = Logger();
 
   //static Set<Polygon> globalPolygons = Set<Polygon>();

--- a/lib/helpers/polygon_helper.dart
+++ b/lib/helpers/polygon_helper.dart
@@ -110,10 +110,13 @@ class PolygonHelper with ChangeNotifier {
         Map<DeviceDetails, Set<PolygonContainer>>();
 
     if (sitesPolygons.containsKey(site)) {
-      //Remove any existing polygons first
-      globalListPolygons.removeWhere((mapOverlay) {
-        return !mapOverlay.polygon!.polygonId.value.contains('developer');
-      });
+      //Remove any existing polygons first (unless multi-tower coverage is on, in which case
+      //other previously-shown towers' polygons should be left alone - see #27)
+      if (!multiTowerCoverage) {
+        globalListPolygons.removeWhere((mapOverlay) {
+          return !mapOverlay.polygon!.polygonId.value.contains('developer');
+        });
+      }
       // Remove this site's labels too, so they don't linger once the polygon is gone.
       labelOverlays.removeWhere((mapOverlay) => mapOverlay.site == site);
 

--- a/lib/helpers/search_helper.dart
+++ b/lib/helpers/search_helper.dart
@@ -7,6 +7,7 @@ import 'package:phonetowers/helpers/polygon_helper.dart';
 import 'package:phonetowers/helpers/site_helper.dart';
 import 'package:phonetowers/networking/api.dart';
 import 'package:phonetowers/networking/response/site_response.dart';
+import 'package:phonetowers/ui/map_common.dart';
 import 'package:phonetowers/utils/app_constants.dart';
 
 typedef void ShowSnackBar({
@@ -105,12 +106,14 @@ class SearchHelper with ChangeNotifier {
           GetLicenceHRP.travel(latLngBoundsBuilder.southwest, 225, minSizeKm));
       latLngBoundsBuilder = boundsFromLatLngList(listLatLongBounds);
 
-      mapController.moveCamera(
-        CameraUpdate.newLatLngBounds(
-          latLngBoundsBuilder,
-          10.0,
-        ),
-      );
+      if (!MapBodyState.lockMap) {
+        mapController.moveCamera(
+          CameraUpdate.newLatLngBounds(
+            latLngBoundsBuilder,
+            10.0,
+          ),
+        );
+      }
 
       showSnackBar!(message: 'Searching is finished!');
     });

--- a/lib/ui/map_common.dart
+++ b/lib/ui/map_common.dart
@@ -307,7 +307,7 @@ class MapBodyState extends AbstractMapBodyState {
                 mapType: mapHelper.getMapType(),
                 buildingsEnabled: false,
                 compassEnabled: !kIsWeb,
-                myLocationButtonEnabled: true,
+                myLocationButtonEnabled: !MapBodyState.lockMap,
                 scrollGesturesEnabled: !MapBodyState.lockMap,
                 trafficEnabled: false,
                 rotateGesturesEnabled: !MapBodyState.lockMap,
@@ -815,6 +815,7 @@ class MapBodyState extends AbstractMapBodyState {
       }
       _followGpsSubscription = state._locationService.onLocationChanged.listen((LocationData location) {
         if (!followGPS) return;
+        if (lockMap) return;
         state.mapController.moveCamera(
           CameraUpdate.newCameraPosition(
             CameraPosition(
@@ -1191,11 +1192,14 @@ class MapBodyState extends AbstractMapBodyState {
 
   void showCustomInfoWindowAsBottomSheet(BuildContext context, Site site) {
     setState(() {
-      //Remove any existing polygons first
+      //Remove any existing polygons first (unless multi-tower coverage is on, in which
+      //case previously-shown polygons should remain rendered alongside the new one)
       //PolygonHelper().globalListPolygons.clear();
-      PolygonHelper.globalListPolygons.removeWhere((mapOverlay) {
-        return !mapOverlay.polygon!.polygonId.value.contains('developer');
-      });
+      if (!PolygonHelper.multiTowerCoverage) {
+        PolygonHelper.globalListPolygons.removeWhere((mapOverlay) {
+          return !mapOverlay.polygon!.polygonId.value.contains('developer');
+        });
+      }
       // Drop this site's labels as well so they don't remain after the polygons are cleared.
       PolygonHelper.labelOverlays.removeWhere((mapOverlay) => mapOverlay.site == site);
     });

--- a/lib/ui/map_common.dart
+++ b/lib/ui/map_common.dart
@@ -254,6 +254,8 @@ class MapBodyState extends AbstractMapBodyState {
   // Follow GPS (drive mode): keeps the map centred on the device's location. Mirrors the
   // Android app's "Follow GPS" toolbar action.
   static bool followGPS = false;
+  // Lock Map: freezes pan/zoom/rotate/tilt so the map can be screenshotted. Requested in #27.
+  static bool lockMap = false;
   static StreamSubscription<LocationData>? _followGpsSubscription;
   static MapBodyState? currentInstance;
   late SharedPreferences prefs;
@@ -306,13 +308,14 @@ class MapBodyState extends AbstractMapBodyState {
                 buildingsEnabled: false,
                 compassEnabled: !kIsWeb,
                 myLocationButtonEnabled: true,
+                scrollGesturesEnabled: !MapBodyState.lockMap,
                 trafficEnabled: false,
-                rotateGesturesEnabled: true,
-                tiltGesturesEnabled: true,
+                rotateGesturesEnabled: !MapBodyState.lockMap,
+                tiltGesturesEnabled: !MapBodyState.lockMap,
                 indoorViewEnabled: false,
                 mapToolbarEnabled: true,
                 zoomControlsEnabled: true,
-                zoomGesturesEnabled: true,
+                zoomGesturesEnabled: !MapBodyState.lockMap,
                 initialCameraPosition: CameraPosition(target: kLagLongBathurst, zoom: kDefaultZoom),
                 markers: _buildMarkerSet(),
                 polygons: PolygonHelper.globalListPolygons.isNotEmpty
@@ -1208,8 +1211,10 @@ class MapBodyState extends AbstractMapBodyState {
     // Get site details
     //String name = site.getNameFormatted();
 
-    // Clear existing polygons on clicking the next one
-    PolygonHelper().clearSitePatterns(false);
+    // Clear existing polygons on clicking the next one (unless multi-tower coverage is on)
+    if (!PolygonHelper.multiTowerCoverage) {
+      PolygonHelper().clearSitePatterns(false);
+    }
 
     _settingModalBottomSheet(context, site);
 

--- a/lib/ui/map_platform.dart
+++ b/lib/ui/map_platform.dart
@@ -54,16 +54,18 @@ abstract class AbstractMapBodyState extends State<MapBody> {
   }
 
   void handleSearchQuery(dynamic mapController, String query) {
-    // Centre the map on Australia
-    mapController.animateCamera(
-      CameraUpdate.newLatLngBounds(
-        LatLngBounds(
-          southwest: LatLng(-44, 113),
-          northeast: LatLng(-10, 154),
+    if (!MapBodyState.lockMap) {
+      // Centre the map on Australia
+      mapController.animateCamera(
+        CameraUpdate.newLatLngBounds(
+          LatLngBounds(
+            southwest: LatLng(-44, 113),
+            northeast: LatLng(-10, 154),
+          ),
+          10.0,
         ),
-        10.0,
-      ),
-    );
+      );
+    }
 
     //Clear the map
     SiteHelper()

--- a/lib/ui/map_web.dart
+++ b/lib/ui/map_web.dart
@@ -53,16 +53,18 @@ abstract class AbstractMapBodyState extends State<MapBody> {
   }
 
   void handleSearchQuery(dynamic mapController, String query) {
-    // Centre the map on Australia
-    mapController.moveCamera(
-      CameraUpdate.newLatLngBounds(
-        LatLngBounds(
-          southwest: LatLng(-44, 113),
-          northeast: LatLng(-10, 154),
+    if (!MapBodyState.lockMap) {
+      // Centre the map on Australia
+      mapController.moveCamera(
+        CameraUpdate.newLatLngBounds(
+          LatLngBounds(
+            southwest: LatLng(-44, 113),
+            northeast: LatLng(-10, 154),
+          ),
+          10.0,
         ),
-        10.0,
-      ),
-    );
+      );
+    }
 
     //Clear the map
     SiteHelper()

--- a/lib/ui/widgets/option_menu.dart
+++ b/lib/ui/widgets/option_menu.dart
@@ -31,6 +31,7 @@ typedef void ShowSnackBar({
 enum OptionMenuItem {
   reloadEverything,
   followGPS,
+  lockMap,
   hideBorders,
   searchSites,
   mapMode,
@@ -77,6 +78,8 @@ class _OptionsMenuState extends State<OptionsMenu> {
     final int precisionIndex = SharedPreferencesHelper.getInt(
         key: SharedPreferencesHelper.kpolygonPrecision, prefs: prefs);
     PolygonHelper.polygonBearingIncrement = _precisionIncrement(precisionIndex);
+    PolygonHelper.multiTowerCoverage =
+        prefs.getBool(SharedPreferencesHelper.kmultiTowerCoverage) ?? false;
   }
 
   static double _precisionIncrement(int index) {
@@ -118,15 +121,20 @@ class _OptionsMenuState extends State<OptionsMenu> {
                   if (_hasSubmenu(item)) ...[
                     Icon(Icons.play_arrow, color: Colors.black54, size: 12)
                   ] else if (item == OptionMenuItem.hideBorders ||
-                      item == OptionMenuItem.followGPS) ...[
+                      item == OptionMenuItem.followGPS ||
+                      item == OptionMenuItem.lockMap) ...[
                     Icon(
                       item == OptionMenuItem.hideBorders
                           ? (PolygonHelper.showPolygonBorders
                               ? Icons.check_box_outline_blank
                               : Icons.check_box)
-                          : (MapBodyState.followGPS
-                              ? Icons.check_box
-                              : Icons.check_box_outline_blank),
+                          : (item == OptionMenuItem.followGPS
+                              ? (MapBodyState.followGPS
+                                  ? Icons.check_box
+                                  : Icons.check_box_outline_blank)
+                              : (MapBodyState.lockMap
+                                  ? Icons.check_box
+                                  : Icons.check_box_outline_blank)),
                       color: Colors.black54,
                       size: 14,
                     )
@@ -148,6 +156,16 @@ class _OptionsMenuState extends State<OptionsMenu> {
             case OptionMenuItem.followGPS:
               {
                 await MapBodyState.toggleFollowGPS();
+                break;
+              }
+            case OptionMenuItem.lockMap:
+              {
+                MapBodyState.lockMap = !MapBodyState.lockMap;
+                widget.showSnackBar(
+                    message: MapBodyState.lockMap
+                        ? 'Map locked — pan/zoom/rotate disabled for screenshots.'
+                        : 'Map unlocked — pan/zoom/rotate enabled.');
+                setState(() {});
                 break;
               }
             case OptionMenuItem.hideBorders:
@@ -260,6 +278,8 @@ class _OptionsMenuState extends State<OptionsMenu> {
         return Strings.reload_everything;
       case OptionMenuItem.followGPS:
         return MapBodyState.followGPS ? Strings.follow_gps_on : Strings.follow_gps_off;
+      case OptionMenuItem.lockMap:
+        return MapBodyState.lockMap ? Strings.unlock_map : Strings.lock_map;
       case OptionMenuItem.hideBorders:
         return PolygonHelper.showPolygonBorders ? Strings.hide_border : Strings.show_border;
       case OptionMenuItem.searchSites:
@@ -309,6 +329,11 @@ class _OptionsMenuState extends State<OptionsMenu> {
       SingleRowItem(isTitle: true, title: Strings.hiding_menu, isEnabled: false),
       hideRadiation,
       disableRefarm,
+      SingleRowItem(
+        title: Strings.hiding_menu_multi_tower,
+        isEnabled: true,
+        isChecked: PolygonHelper.multiTowerCoverage,
+      ),
     ];
     final SingleRowItem? chosen = await showSingleRowOptionMenu(items, kHidingMenu);
     if (chosen == null) return;
@@ -336,6 +361,20 @@ class _OptionsMenuState extends State<OptionsMenu> {
           message: DeviceDetails.refarmEnabled
               ? 'Refarming on: legacy 3G licences in 4G/5G bands shown at their current reuse (4G LTE).'
               : 'Refarming off: showing the literal licence type (e.g. 3G UMTS).');
+    } else if (chosen.title == Strings.hiding_menu_multi_tower) {
+      PolygonHelper.multiTowerCoverage = !PolygonHelper.multiTowerCoverage;
+      SharedPreferencesHelper.saveBoolean(
+          key: SharedPreferencesHelper.kmultiTowerCoverage,
+          value: PolygonHelper.multiTowerCoverage,
+          prefs: prefs);
+      if (!PolygonHelper.multiTowerCoverage) {
+        PolygonHelper().clearSitePatterns(false);
+      }
+      setState(() {});
+      widget.showSnackBar(
+          message: PolygonHelper.multiTowerCoverage
+              ? 'Multi-Tower Coverage on: tapping towers adds their coverage to the map.'
+              : 'Multi-Tower Coverage off: tapping a tower replaces the previous coverage.');
     }
   }
 

--- a/lib/ui/widgets/option_menu.dart
+++ b/lib/ui/widgets/option_menu.dart
@@ -163,8 +163,8 @@ class _OptionsMenuState extends State<OptionsMenu> {
                 MapBodyState.lockMap = !MapBodyState.lockMap;
                 widget.showSnackBar(
                     message: MapBodyState.lockMap
-                        ? 'Map locked — pan/zoom/rotate disabled for screenshots.'
-                        : 'Map unlocked — pan/zoom/rotate enabled.');
+                        ? 'Map locked — all camera movement (gestures, my location, Follow GPS, search) disabled for screenshots.'
+                        : 'Map unlocked — camera movement enabled again.');
                 setState(() {});
                 break;
               }

--- a/lib/utils/shared_pref_helper.dart
+++ b/lib/utils/shared_pref_helper.dart
@@ -43,6 +43,7 @@ class SharedPreferencesHelper {
   static final String kshowPolygonBorders = 'showPolygonBorders';
   static final String kMapMode = 'mapMode';
   static final String kdrawPolygonsOnClick = 'drawPolygonsOnClick';
+  static final String kmultiTowerCoverage = 'multiTowerCoverage';
   static final String kcalculateTerrain = 'calculateTerrain';
   static final String krefarmEnabled = 'refarmEnabled';
   static final String kpolygonPrecision = 'polygonPrecision';

--- a/lib/utils/strings.dart
+++ b/lib/utils/strings.dart
@@ -61,6 +61,8 @@ class Strings {
   static String follow_gps_off = 'Follow GPS';
   static String hide_border = 'Hide Borders';
   static String show_border = 'Show Borders';
+  static String lock_map = 'Lock Map';
+  static String unlock_map = 'Unlock Map';
   static String search_sites = 'Search Sites';
   static String clear_map = 'Clear Map';
   static String clear_polygons = 'Clear Polygons';
@@ -75,6 +77,7 @@ class Strings {
   static String hiding_menu = 'Hiding Menu';
   static String hiding_menu_hide_radiation = 'Hide Radiation on Click';
   static String hiding_menu_draw_radiation = 'Draw Radiation on Click';
+  static String hiding_menu_multi_tower = 'Multi-Tower Coverage';
   static String disable_refarming = 'Disable frequency refarming';
   static String disable_refarming_summary =
       'When on, legacy 3G (UMTS) licences in bands now run as 4G/5G are shown at their current reuse (4G LTE).';


### PR DESCRIPTION
## Summary

Implements #27 (split from #15).

Two features requested in the issue:

1. **Multi-Tower Coverage** (new Hiding Menu toggle): when on, tapping a tower no longer clears the existing coverage polygons, so multiple towers' coverage accumulates on the map. Off by default (preserves original behaviour). Persisted to `SharedPreferences`.
2. **Lock Map** (new top-level ⋯ menu item, placed right after Follow GPS): freezes pan / zoom / rotate / tilt gestures so the user can screenshot or study a fixed coverage area. Mirrors the Android screenshot-lock behaviour.

## Changes
- `lib/helpers/polygon_helper.dart`: added `static bool multiTowerCoverage`.
- `lib/ui/map_common.dart`: added `MapBodyState.lockMap`; GoogleMap gestures (`scrollGesturesEnabled`, `zoomGesturesEnabled`, `rotateGesturesEnabled`, `tiltGesturesEnabled`) now gate on `!lockMap`; marker tap no longer clears polygons when `multiTowerCoverage` is on.
- `lib/ui/widgets/option_menu.dart`: added `OptionMenuItem.lockMap`; checkbox UI for followGPS/lockMap/hideBorders; Hiding Menu gets a `Multi-Tower Coverage` item (checked when on).
- `lib/utils/strings.dart`: added `lock_map`, `unlock_map`, `hiding_menu_multi_tower`.
- `lib/utils/shared_pref_helper.dart`: added `kmultiTowerCoverage`.
- `docs/USER_GUIDE.md`: documented both features.

## Verification
- `flutter analyze`: no errors.

This PR was created by an AI agent (OpenHands) on behalf of @bradrushworth.