### PR TITLE
Release 1.12.1+113: fix ads not displaying and iOS ad-free purchases not recognised

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -86,6 +86,39 @@ Tests are in `test/pathloss/` and are ported from the Java app's test suite:
 
 Run with: `flutter test test/pathloss/`
 
+## Ads and billing (lib/helpers/ads_helper.dart, lib/helpers/purchase_helper.dart)
+Non-subscribed users see an inline adaptive AdMob banner at the bottom of the map; purchasing
+`yearly_adfree` or `permanent_adfree` (via `in_app_purchase`/`in_app_purchase_storekit`) removes it.
+
+### Ads
+- **`AdsHelper`** (singleton): loads the banner via `AdSize.getInlineAdaptiveBannerAdSize`, whose
+  `AdSize` **always reports `height == 0`** — that's a placeholder size, not the rendered size. The
+  real size is only known after load, via `BannerAd.getPlatformAdSize()`, which `AdsHelper` fetches
+  in `onAdLoaded` and caches on `loadedAdSize`. Any UI sizing a banner container **must** use
+  `loadedAdSize`, never `bannerAd.size` — using the latter silently collapses the ad to zero height
+  even though it loaded successfully (this was a real bug, fixed in `AdsHelper`/`AdBannerContainer`).
+- **`AdBannerContainer`** (`lib/ui/widgets/ad_banner_container.dart`): the widget that reserves
+  space for the banner and shows the "Advertisement" label, decoupled from `google_mobile_ads`
+  types (`Size`/plain `Widget` instead of `AdSize`/`AdWidget`) so its sizing logic can be exercised
+  in a plain widget test without a platform channel. Covered by
+  `test/ui/widgets/ad_banner_container_test.dart`.
+
+### Billing
+- **`PurchaseHelper`** (singleton, `ChangeNotifier`): wraps `in_app_purchase` /
+  `in_app_purchase_storekit`. The pure decision logic (donation vs. yearly vs. permanent, yearly
+  expiry) lives in `lib/helpers/entitlement_evaluator.dart#evaluateEntitlements`, kept
+  side-effect-free so it's unit-testable without StoreKit.
+- **iOS StoreKit2 gotcha**: `in_app_purchase_storekit` defaults to StoreKit2
+  (`InAppPurchaseStoreKitPlatform._useStoreKit2 = true`). In plugin versions up to 0.4.10.x it
+  reported `PurchaseDetails.transactionDate` as a local-time `"yyyy-MM-dd HH:mm:ss"` string —
+  Android and StoreKit1 report epoch milliseconds instead, and naive `int.tryParse`-only parsing
+  silently failed on iOS, so yearly purchases were never recognised as active. This was fixed
+  upstream in 0.4.11+1 (StoreKit2 now reports epoch milliseconds too), which this app picked up via
+  `flutter pub upgrade`. `evaluateEntitlements` still parses both formats via
+  `_parseTransactionDateMillis` (tries `int.tryParse` first, falls back to `DateTime.parse`) as
+  defense-in-depth against older/downgraded plugin versions. Covered by
+  `test/purchase_helper_test.dart`.
+
 ## Documentation must be kept in sync
 Whenever you add, change, or remove a user-facing feature, command, or behaviour in this
 project, you MUST also update the relevant documentation before considering the task complete:

--- a/README.md
+++ b/README.md
@@ -71,7 +71,10 @@ Both apps use the platform store for entitlements:
   They are repeatable and do **not** remove ads.
 
 A banner advertisement is shown to non-subscribed users only after an ad has actually loaded; the
-"Advertisement" label is hidden until then (and whenever ads are not shown).
+"Advertisement" label is hidden until then (and whenever ads are not shown). The banner is sized
+from the ad's actual rendered dimensions (`AdsHelper.loadedAdSize`), not the placeholder `AdSize`
+used to request an inline adaptive banner (which always reports `height == 0`) — see the "Ads and
+billing" section of `AGENTS.md` and `test/ui/widgets/ad_banner_container_test.dart`.
 
 ### Signal-propagation math consistency
 

--- a/lib/helpers/ads_helper.dart
+++ b/lib/helpers/ads_helper.dart
@@ -11,6 +11,14 @@ class AdsHelper {
   AdsHelper._internal();
 
   BannerAd? bannerAd;
+
+  // Inline adaptive banner sizes (used for [showBannerAd]) always report
+  // height 0 on [BannerAd.size] — the real height is only known once the ad
+  // has loaded, via [BannerAd.getPlatformAdSize]. Widgets must size
+  // themselves from this field instead of `bannerAd!.size`, or the loaded ad
+  // renders into a zero-height container and never appears on screen.
+  AdSize? loadedAdSize;
+
   static String androidAdmobAppId = 'ca-app-pub-6156750794650893~5795736618';
   static String androidPortraitAdUnitId = 'ca-app-pub-6156750794650893/7272469813';
   static String androidLandscapeAdUnitId = 'ca-app-pub-6156750794650893/2424837889';
@@ -75,10 +83,14 @@ class AdsHelper {
       request: adRequestBuilder,
       size: bannerAdSize,
       listener: BannerAdListener(
-        onAdLoaded: (ad) {
+        onAdLoaded: (ad) async {
           // Called when an ad is successfully received.
           debugPrint("Ads was loaded.");
           bannerAd = ad as BannerAd;
+          // For inline adaptive sizes, `ad.size` is always the requested
+          // placeholder (height 0) — fetch the real rendered size so the
+          // widget knows how tall to draw itself.
+          loadedAdSize = await bannerAd!.getPlatformAdSize() ?? bannerAd!.size;
           onAdLoaded?.call();
         },
         onAdFailedToLoad: (ad, err) {
@@ -93,6 +105,7 @@ class AdsHelper {
   void hideBannerAd() async {
     await bannerAd?.dispose();
     bannerAd = null;
+    loadedAdSize = null;
     debugPrint("Ads: hideBannerAd()");
   }
 }

--- a/lib/helpers/entitlement_evaluator.dart
+++ b/lib/helpers/entitlement_evaluator.dart
@@ -79,8 +79,7 @@ Future<PurchaseEntitlement> evaluateEntitlements(
   String timeToExpire = '';
   int yearlyExpiryEpoch = 0;
   if (oneYear != null) {
-    final int purchaseTime =
-        int.tryParse(oneYear.transactionDate ?? '') ?? 0;
+    final int purchaseTime = _parseTransactionDateMillis(oneYear.transactionDate) ?? 0;
     if (purchaseTime > 0) {
       if (purchaseTime < nowMillis - expiryPeriod) {
         // The one year of ad-free is over.
@@ -116,4 +115,24 @@ Future<PurchaseEntitlement> evaluateEntitlements(
     yearlyPurchaseExpired: yearlyExpired,
     yearlyExpiryEpoch: yearlyExpiryEpoch,
   );
+}
+
+/// Parses [PurchaseDetails.transactionDate] into epoch milliseconds.
+///
+/// The format varies by platform/plugin path:
+///   * Android and iOS StoreKit1 report epoch milliseconds as a string.
+///   * iOS StoreKit2 (the `in_app_purchase_storekit` default since 0.4.x) reports epoch
+///     milliseconds too as of 0.4.11+1 — but 0.4.10.x reported a `"yyyy-MM-dd HH:mm:ss"`
+///     local-time string instead, which silently fails `int.tryParse` and left yearly
+///     purchases on iOS permanently unrecognised (ads never removed). Both formats are
+///     handled here so this keeps working regardless of platform or plugin version.
+int? _parseTransactionDateMillis(String? transactionDate) {
+  if (transactionDate == null || transactionDate.isEmpty) return null;
+  final int? epochMillis = int.tryParse(transactionDate);
+  if (epochMillis != null) return epochMillis;
+  try {
+    return DateTime.parse(transactionDate).millisecondsSinceEpoch;
+  } on FormatException {
+    return null;
+  }
 }

--- a/lib/ui/map_common.dart
+++ b/lib/ui/map_common.dart
@@ -38,6 +38,7 @@ import 'package:phonetowers/networking/api.dart';
 import 'package:phonetowers/networking/response/site_response.dart';
 import 'package:phonetowers/ui/map_platform.dart'
     if (dart.library.js) 'package:phonetowers/ui/map_web.dart';
+import 'package:phonetowers/ui/widgets/ad_banner_container.dart';
 import 'package:phonetowers/ui/widgets/navigation_menu.dart';
 import 'package:phonetowers/ui/widgets/option_menu.dart';
 import 'package:phonetowers/utils/geo_hash.dart';
@@ -476,32 +477,16 @@ class MapBodyState extends AbstractMapBodyState with WidgetsBindingObserver {
           child: Align(
             alignment: Alignment.bottomCenter,
             child: SafeArea(
-              child: Container(
-                height: AdsHelper().bannerAd == null ? 0 : 100,
-                color: Colors.white,
-                alignment: AlignmentGeometry.center,
-                child: Column(
-                  children: [
-                    if (AdsHelper().bannerAd != null)
-                      Text(
-                        "Advertisement",
-                        maxLines: 1,
-                        textAlign: TextAlign.center,
-                        style: TextStyle(color: Colors.grey),
+              child: AdBannerContainer(
+                adSize: AdsHelper().loadedAdSize == null
+                    ? null
+                    : Size(
+                        AdsHelper().loadedAdSize!.width.toDouble(),
+                        AdsHelper().loadedAdSize!.height.toDouble(),
                       ),
-                    SizedBox(
-                      width: AdsHelper().bannerAd == null
-                          ? 0
-                          : AdsHelper().bannerAd!.size.width.toDouble(),
-                      height: AdsHelper().bannerAd == null
-                          ? 0
-                          : AdsHelper().bannerAd!.size.height.toDouble(),
-                      child: AdsHelper().bannerAd == null
-                          ? Container()
-                          : AdWidget(ad: AdsHelper().bannerAd!),
-                    ),
-                  ],
-                ),
+                adChild: AdsHelper().bannerAd == null
+                    ? null
+                    : AdWidget(ad: AdsHelper().bannerAd!),
               ),
             ),
           ),

--- a/lib/ui/widgets/ad_banner_container.dart
+++ b/lib/ui/widgets/ad_banner_container.dart
@@ -1,0 +1,51 @@
+import 'package:flutter/material.dart';
+
+/// Bottom-of-screen container that reserves space for a banner ad only once
+/// the ad's actual rendered size is known.
+///
+/// Inline adaptive banner ads (see [AdsHelper.showBannerAd]) always report
+/// `height == 0` on the requested [BannerAd.size] — the real height is only
+/// known once the ad has loaded, via `BannerAd.getPlatformAdSize()` (cached
+/// as [AdsHelper.loadedAdSize]). Sizing this container from the requested
+/// size instead of the loaded size collapses it to zero height, so a
+/// successfully-loaded ad never becomes visible. See
+/// `test/ui/widgets/ad_banner_container_test.dart` for the regression test.
+///
+/// [adSize] and [adChild] are plain Flutter types (not `AdSize`/`AdWidget`)
+/// so this widget — and its sizing logic — can be exercised in a widget test
+/// without depending on the `google_mobile_ads` platform channel.
+class AdBannerContainer extends StatelessWidget {
+  const AdBannerContainer({super.key, required this.adSize, required this.adChild});
+
+  /// The actual rendered size of the loaded ad, or null if no ad has loaded.
+  final Size? adSize;
+
+  /// The platform ad view to display once [adSize] is known, or null.
+  final Widget? adChild;
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      key: const Key('ad-banner-outer'),
+      height: adSize == null ? 0 : 100,
+      color: Colors.white,
+      alignment: AlignmentGeometry.center,
+      child: Column(
+        children: [
+          if (adSize != null)
+            Text(
+              "Advertisement",
+              maxLines: 1,
+              textAlign: TextAlign.center,
+              style: TextStyle(color: Colors.grey),
+            ),
+          SizedBox(
+            width: adSize == null ? 0 : adSize!.width,
+            height: adSize == null ? 0 : adSize!.height,
+            child: adSize == null || adChild == null ? Container() : adChild,
+          ),
+        ],
+      ),
+    );
+  }
+}

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -5,18 +5,18 @@ packages:
     dependency: transitive
     description:
       name: _fe_analyzer_shared
-      sha256: cd6add6f846f35fb79f3c315296703c1a24f3cfd7f4739d91a74961c1c7e9f1b
+      sha256: "9a3386eea899815698dd55995277cf7cb8572ee52b399a6edfb7ae2b50e5fc19"
       url: "https://pub.dev"
     source: hosted
-    version: "100.0.0"
+    version: "105.0.0"
   _flutterfire_internals:
     dependency: transitive
     description:
       name: _flutterfire_internals
-      sha256: "460e9e684edb461d85498fc166ff8416f303f22216838d302d80676b348c6a4c"
+      sha256: "6727cf2ced9b104abca9daa278380be2eca2b98ce33d4b46f11708e387dc6b4d"
       url: "https://pub.dev"
     source: hosted
-    version: "1.3.75"
+    version: "1.3.76"
   after_layout:
     dependency: "direct main"
     description:
@@ -29,10 +29,10 @@ packages:
     dependency: transitive
     description:
       name: analyzer
-      sha256: "6ba98576948803398b69e3a444df24eacdbe12ed699c7014e120ea38552debbf"
+      sha256: "62993bed6eadbe9596c5c20d5c167e7bc563c5fe266657a04ddeb93bdb84f4c9"
       url: "https://pub.dev"
     source: hosted
-    version: "13.0.0"
+    version: "14.1.0"
   app_tracking_transparency:
     dependency: "direct main"
     description:
@@ -45,10 +45,10 @@ packages:
     dependency: transitive
     description:
       name: archive
-      sha256: a96e8b390886ee8abb49b7bd3ac8df6f451c621619f52a26e815fdcf568959ff
+      sha256: be169cf6ac481e052c4538715d88841d567150dfe1df38aaec76461a4e7b39f2
       url: "https://pub.dev"
     source: hosted
-    version: "4.0.9"
+    version: "4.1.0"
   args:
     dependency: transitive
     description:
@@ -85,34 +85,34 @@ packages:
     dependency: transitive
     description:
       name: build
-      sha256: "45d14a0fb23e018d8287c32fc98d726ce466b231928ed9b9200f29bd3ccd39ae"
+      sha256: b94f5da9ed3d081fd4ecc426c260998b5f4f4eb2f6d89b7e5472edef0b2b2a1b
       url: "https://pub.dev"
     source: hosted
-    version: "4.0.7"
+    version: "4.0.10"
   build_config:
     dependency: transitive
     description:
       name: build_config
-      sha256: f2c223156a26eea323e6244b85141d76413a80aeee9fe0b380773789fabaf8ae
+      sha256: "94eaf6708fe64408c632ef2689ca3777b112f9421306ccf4f8c84d7c5c9f83f8"
       url: "https://pub.dev"
     source: hosted
-    version: "1.3.1"
+    version: "1.3.2"
   build_daemon:
     dependency: transitive
     description:
       name: build_daemon
-      sha256: fd754058c342243718d5171a95f352cfc9fcf0cba8cfa26df67cb13a5836db78
+      sha256: "79e05eaf15a48d7230b053a4363b8eaac0cc234bbd0134c3229455481f55cbc6"
       url: "https://pub.dev"
     source: hosted
-    version: "4.1.2"
+    version: "4.1.5"
   build_runner:
     dependency: "direct dev"
     description:
       name: build_runner
-      sha256: "5367e521935b102bdf1e735d2aab461e36b2edca6517662d088dd04cc39f8d16"
+      sha256: "90363d438bd9f84a4d5bbb83352251f57d2d9d771bc95a44e6a33fe25fa52774"
       url: "https://pub.dev"
     source: hosted
-    version: "2.15.1"
+    version: "2.16.0"
   built_collection:
     dependency: transitive
     description:
@@ -125,10 +125,10 @@ packages:
     dependency: transitive
     description:
       name: built_value
-      sha256: "34e4067d30ce212937df995f03b69992eea683539ceeac7f679a1f1eba055b56"
+      sha256: "31b24be6615ec7fcf70b3aa5a7469fe35826485e639a16dd7eb83ba30e4cc6a8"
       url: "https://pub.dev"
     source: hosted
-    version: "8.12.6"
+    version: "8.12.7"
   characters:
     dependency: transitive
     description:
@@ -213,26 +213,26 @@ packages:
     dependency: transitive
     description:
       name: dart_style
-      sha256: "59d53ef8eaed9d288ed9767618e2b31c4fa0383a127db59d5eb2e737a7638a60"
+      sha256: "3f88fc9c96c568d631356507355a2d1e983ee000c9ac008bdcb39b5bf53ce777"
       url: "https://pub.dev"
     source: hosted
-    version: "3.1.9"
+    version: "3.1.12"
   dio:
     dependency: "direct main"
     description:
       name: dio
-      sha256: ea2bad3c89a27635ce2d85cce4d6b199da49a5a48ec77b03e45b65a3b90922b0
+      sha256: "0df44ebba85e503958eb75d07eedd3c86275a58c1d3eda2f2ce8f0a2c3abbb3c"
       url: "https://pub.dev"
     source: hosted
-    version: "5.10.0"
+    version: "5.11.0"
   dio_web_adapter:
     dependency: transitive
     description:
       name: dio_web_adapter
-      sha256: dd58dc3861eb36edb13b217efc006a1c21e5bbc341de8c229b85634fa5e362e4
+      sha256: "0786d0b7295a373de356fc0af4f6f1d0ab2844ed31b19dfc5e7556b70e24212c"
       url: "https://pub.dev"
     source: hosted
-    version: "2.2.0"
+    version: "2.2.1"
   fake_async:
     dependency: transitive
     description:
@@ -261,66 +261,66 @@ packages:
     dependency: "direct main"
     description:
       name: firebase_analytics
-      sha256: "47b68927bc4abd6d7b4e2ddfe7c64fe087cca5f96d0c2b8d9d6deb6120c10ad6"
+      sha256: a139dd0ada1c6e0ffd77bfdb877ac9061ffdec7c415e3e06113bdf8844db771f
       url: "https://pub.dev"
     source: hosted
-    version: "12.4.5"
+    version: "12.4.6"
   firebase_analytics_platform_interface:
     dependency: transitive
     description:
       name: firebase_analytics_platform_interface
-      sha256: "36ce5feb5a996381e6411792eaa00e89178e75943e54ac8f14a8296b6e9a3e88"
+      sha256: "448c319ea895da002e43892c7d3f15dccbc3c4c3b81d3e307e37da885ea52bdf"
       url: "https://pub.dev"
     source: hosted
-    version: "6.0.5"
+    version: "6.0.6"
   firebase_analytics_web:
     dependency: transitive
     description:
       name: firebase_analytics_web
-      sha256: c12358983c927093cd40d42feb0cb05c8594d3a9b56ab5ad303bec2b8838d252
+      sha256: "67f287a0df75f27eafdd4a66a41e44f232c3aba713ea4794a1159893665a8bf5"
       url: "https://pub.dev"
     source: hosted
-    version: "0.6.1+11"
+    version: "0.6.1+12"
   firebase_core:
     dependency: "direct main"
     description:
       name: firebase_core
-      sha256: "6f22d1c62e0c20976f02cd842c7b7cd3c0f561cc2052586411871045c08860c9"
+      sha256: "9478ca6700c02d315c6aba37e206e612317f98bb4f335bb1cbd6e0ce67dcf764"
       url: "https://pub.dev"
     source: hosted
-    version: "4.12.1"
+    version: "4.13.0"
   firebase_core_platform_interface:
     dependency: transitive
     description:
       name: firebase_core_platform_interface
-      sha256: f74d1d6fabccf7743b0144c2ed363d81049e258e22428ebb6fb0faec2fa7d938
+      sha256: e28f9afdcb5b0f0a8ea74ea3b322f5a7592c81cb45dd9d189913bdae08a2089a
       url: "https://pub.dev"
     source: hosted
-    version: "8.0.0"
+    version: "8.1.0"
   firebase_core_web:
     dependency: transitive
     description:
       name: firebase_core_web
-      sha256: ddab99d709b8c27dd47576eb05a1e719e07a2aa45c009a49ae92ac4d2a8ca555
+      sha256: f471a288b0101a45567548322ac4a5ad31e3ecbf87a576dcc0e424e6a11e04ea
       url: "https://pub.dev"
     source: hosted
-    version: "3.9.1"
+    version: "3.10.0"
   firebase_crashlytics:
     dependency: "direct main"
     description:
       name: firebase_crashlytics
-      sha256: "9855d3e2286c3e4439cf7d48c740bdf282ac165f29c7551dcdaf121925c59a28"
+      sha256: "96c1d85de9eddc07061d3f7e2fb75596e75a45c9cec9c2e3a7cc9f97e6f3a748"
       url: "https://pub.dev"
     source: hosted
-    version: "5.2.6"
+    version: "5.2.7"
   firebase_crashlytics_platform_interface:
     dependency: transitive
     description:
       name: firebase_crashlytics_platform_interface
-      sha256: aab14de92555ccf8c8616fc1b649272aef04dadb07f986e166e1d36d158f7bd1
+      sha256: "47d83b71fd39c580297c696a507a7c2652680ea2045e40c6c4e3c371b0ee7bc6"
       url: "https://pub.dev"
     source: hosted
-    version: "3.8.26"
+    version: "3.8.27"
   fixnum:
     dependency: transitive
     description:
@@ -407,18 +407,18 @@ packages:
     dependency: transitive
     description:
       name: google_maps
-      sha256: "5d410c32112d7c6eb7858d359275b2aa04778eed3e36c745aeae905fb2fa6468"
+      sha256: "6811afff50dc410b860622ac89df125f5be1eada3ad69197e4c24dd18f2ef0e0"
       url: "https://pub.dev"
     source: hosted
-    version: "8.2.0"
+    version: "8.3.0"
   google_maps_flutter:
     dependency: "direct main"
     description:
       name: google_maps_flutter
-      sha256: f4040715c2998144a46cfc0fd91ee83226655af069dfed3d2b84552dc5e4facb
+      sha256: "90f9d01eb282f996769defff95f15ebd8650a79c7e105c42a51a23f1376df612"
       url: "https://pub.dev"
     source: hosted
-    version: "2.17.1"
+    version: "2.18.0"
   google_maps_flutter_android:
     dependency: transitive
     description:
@@ -455,10 +455,10 @@ packages:
     dependency: "direct main"
     description:
       name: google_mobile_ads
-      sha256: "6029f6c48bc9b6b47767ddbb4847683048a2f006d418c871bd93c5eb6a8e5c3c"
+      sha256: "8094e1ace8b0da33fe79027ca6959763c96a28855025cb7c8ec60838e1d56ed8"
       url: "https://pub.dev"
     source: hosted
-    version: "9.0.0"
+    version: "9.1.0"
   graphs:
     dependency: transitive
     description:
@@ -471,10 +471,10 @@ packages:
     dependency: transitive
     description:
       name: hooks
-      sha256: "9a62a50b50b769a737bc0a8ff381f333529df3ab746b2f6b02e83760231455ba"
+      sha256: eaac480a35ec0814146c2c48d96aaa829e0e44a7662c88ae84c9edf4bc35651f
       url: "https://pub.dev"
     source: hosted
-    version: "2.0.2"
+    version: "2.2.0"
   html:
     dependency: transitive
     description:
@@ -511,10 +511,10 @@ packages:
     dependency: transitive
     description:
       name: image
-      sha256: "6300175e00616bbc832e2fc91bfa4d776af5402c81c7151bee6905bb08473c52"
+      sha256: "1976370a4df3091bb0f72409c187ad1f9132a818bc6b95ca59c0bae1c75c688e"
       url: "https://pub.dev"
     source: hosted
-    version: "4.9.1"
+    version: "4.9.2"
   in_app_purchase:
     dependency: "direct main"
     description:
@@ -543,10 +543,10 @@ packages:
     dependency: "direct main"
     description:
       name: in_app_purchase_storekit
-      sha256: "47d63717270133fcfa1ff8e144f6aaf9d498fa3884de43e24909737da55aedd8"
+      sha256: "9602e249a0e30351f047d5715957f27709ed7b42f631fba8941dcad51489932a"
       url: "https://pub.dev"
     source: hosted
-    version: "0.4.10+1"
+    version: "0.4.11+1"
   in_app_review:
     dependency: "direct main"
     description:
@@ -588,18 +588,26 @@ packages:
     dependency: transitive
     description:
       name: jni
-      sha256: c2230682d5bc2362c1c9e8d3c7f406d9cbba23ab3f2e203a025dd47e0fb2e68f
+      sha256: f038e58b4dc2c9037f50e233175086337e0b305e356d28211bf55f21c504cbd3
       url: "https://pub.dev"
     source: hosted
-    version: "1.0.0"
+    version: "1.0.3"
   jni_flutter:
     dependency: transitive
     description:
       name: jni_flutter
-      sha256: "8b59e590786050b1cd866677dddaf76b1ade5e7bc751abe04b86e84d379d3ba6"
+      sha256: "7b717011ea40d04fd47c2731d3d1d36eb99eba3435c2753d62489e8c3c9991d5"
       url: "https://pub.dev"
     source: hosted
-    version: "1.0.1"
+    version: "1.0.2"
+  jni_util:
+    dependency: transitive
+    description:
+      name: jni_util
+      sha256: "1ba86da04a5f2bf18fde2edb235587e70c5b0fc5bd4ba955f46b00942c3fc35f"
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.0.0"
   json_annotation:
     dependency: "direct main"
     description:
@@ -724,18 +732,18 @@ packages:
     dependency: transitive
     description:
       name: objective_c
-      sha256: "6cb691c686fa2838c6deb34980d426145c2a5d537491cb83d463c33cdbc726ed"
+      sha256: b7fb95a6d9a4f009edd63dc5ac69f07420b23a16161c6dd8660290b59c602e8e
       url: "https://pub.dev"
     source: hosted
-    version: "9.4.1"
+    version: "9.5.0"
   package_config:
     dependency: transitive
     description:
       name: package_config
-      sha256: f096c55ebb7deb7e384101542bfba8c52696c1b56fca2eb62827989ef2353bbc
+      sha256: ffcf4cf3d6c0b74ac43708d9f56625506e8a68aa935abe9d267a7330f320eb5d
       url: "https://pub.dev"
     source: hosted
-    version: "2.2.0"
+    version: "3.0.0"
   path:
     dependency: "direct main"
     description:
@@ -812,42 +820,34 @@ packages:
     dependency: transitive
     description:
       name: permission_handler_apple
-      sha256: "79dfa1df734798aa3cfdad166d3a3698c206d8813de13516ea1071b5d7e2f420"
+      sha256: f49cb15a064ea9d974fc7fbb302099353b7b170d07284e86e264561579e5bcf8
       url: "https://pub.dev"
     source: hosted
-    version: "9.4.10"
+    version: "9.6.1"
   permission_handler_html:
     dependency: transitive
     description:
       name: permission_handler_html
-      sha256: "38f000e83355abb3392140f6bc3030660cfaef189e1f87824facb76300b4ff24"
+      sha256: "6ea98b3f17f60d3b527f2647ed2ab4dc0f6bfe25b22cb1c363f5d8f62252f6ac"
       url: "https://pub.dev"
     source: hosted
-    version: "0.1.3+5"
+    version: "0.1.4+1"
   permission_handler_platform_interface:
     dependency: transitive
     description:
       name: permission_handler_platform_interface
-      sha256: eb99b295153abce5d683cac8c02e22faab63e50679b937fa1bf67d58bb282878
+      sha256: a5c8a97ecf5616112a5b16d4b8e9ec0e5ae90ef63ac69c0d7b8ae240be760b23
       url: "https://pub.dev"
     source: hosted
-    version: "4.3.0"
+    version: "4.4.0"
   permission_handler_windows:
     dependency: transitive
     description:
       name: permission_handler_windows
-      sha256: "1a790728016f79a41216d88672dbc5df30e686e811ad4e698bfc51f76ad91f1e"
+      sha256: caeae01858a0a7d2df67a445ac98e1ad95e55a0e77c73044f4e9b1c8c2289cbd
       url: "https://pub.dev"
     source: hosted
-    version: "0.2.1"
-  petitparser:
-    dependency: transitive
-    description:
-      name: petitparser
-      sha256: "91bd59303e9f769f108f8df05e371341b15d59e995e6806aefab827b58336675"
-      url: "https://pub.dev"
-    source: hosted
-    version: "7.0.2"
+    version: "0.2.2"
   platform:
     dependency: transitive
     description:
@@ -876,10 +876,10 @@ packages:
     dependency: transitive
     description:
       name: posix
-      sha256: "185ef7606574f789b40f289c233efa52e96dead518aed988e040a10737febb07"
+      sha256: bc1bad54ad2b735816e31f8d4600cfde6c7839975085ddfbca48b6c9f7c4044e
       url: "https://pub.dev"
     source: hosted
-    version: "6.5.0"
+    version: "6.5.2"
   process:
     dependency: transitive
     description:
@@ -916,10 +916,10 @@ packages:
     dependency: transitive
     description:
       name: record_use
-      sha256: "2551bd8eecfe95d14ae75f6021ad0248be5c27f138c2ec12fcb52b500b3ba1ed"
+      sha256: "1cb8564af8d43b464294411db9217f5ec04891c6f22ee2c32d73ae05e88a6bd2"
       url: "https://pub.dev"
     source: hosted
-    version: "0.6.0"
+    version: "1.1.1"
   sanitize_html:
     dependency: transitive
     description:
@@ -1153,10 +1153,10 @@ packages:
     dependency: transitive
     description:
       name: vm_service
-      sha256: "0016aef94fc66495ac78af5859181e3f3bf2026bd8eecc72b9565601e19ab360"
+      sha256: "5f37239c4851efcef929cea7824e76df7f2f0970aef85d66bbc430afa40e72f0"
       url: "https://pub.dev"
     source: hosted
-    version: "15.2.0"
+    version: "15.3.0"
   watcher:
     dependency: transitive
     description:
@@ -1209,10 +1209,10 @@ packages:
     dependency: transitive
     description:
       name: webview_flutter_android
-      sha256: a97db7a44f8e71af2f3971c45550a08cce1fb60059c1b8e534251e6cfb753490
+      sha256: b98656fa4461f8cc05c48a778b4d4883e60ec63e1778348f363f9bb9a477745d
       url: "https://pub.dev"
     source: hosted
-    version: "4.13.0"
+    version: "4.14.0"
   webview_flutter_platform_interface:
     dependency: transitive
     description:
@@ -1237,14 +1237,6 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.1.0"
-  xml:
-    dependency: transitive
-    description:
-      name: xml
-      sha256: "67f0aff7be013d107995e9b75bf4e7f2c3ef2dfdb2c8e68024bba0a7fd5756a4"
-      url: "https://pub.dev"
-    source: hosted
-    version: "7.0.1"
   yaml:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -12,7 +12,7 @@ publish_to: 'none'
 # In iOS, build-name is used as CFBundleShortVersionString while build-number used as CFBundleVersion.
 # Read more about iOS versioning at
 # https://developer.apple.com/library/archive/documentation/General/Reference/InfoPlistKeyReference/Articles/CoreFoundationKeys.html
-version: 1.12.0+112
+version: 1.12.1+113
 
 environment:
   sdk: '>=3.9.2 <4.0.0'

--- a/test/purchase_helper_test.dart
+++ b/test/purchase_helper_test.dart
@@ -91,6 +91,27 @@ void main() {
       expect(e.timeToExpireYearlySubscription, isEmpty);
     });
 
+    test('yearly active with StoreKit2 "yyyy-MM-dd HH:mm:ss" date -> subscribed', () async {
+      // iOS StoreKit2 (in_app_purchase_storekit's default transaction path)
+      // reports transactionDate as a local-time "yyyy-MM-dd HH:mm:ss" string
+      // rather than epoch milliseconds. This must not be treated as expired/absent.
+      final DateTime purchasedAt = DateTime.now().subtract(const Duration(days: 30));
+      final String formatted =
+          '${purchasedAt.year.toString().padLeft(4, '0')}-'
+          '${purchasedAt.month.toString().padLeft(2, '0')}-'
+          '${purchasedAt.day.toString().padLeft(2, '0')} '
+          '${purchasedAt.hour.toString().padLeft(2, '0')}:'
+          '${purchasedAt.minute.toString().padLeft(2, '0')}:'
+          '${purchasedAt.second.toString().padLeft(2, '0')}';
+      final PurchaseEntitlement e = await evaluateEntitlements(
+        [_purchase(skuSubscribeOneYear, formatted)],
+        nowMillis: DateTime.now().millisecondsSinceEpoch,
+        expiryPeriod: _expiryPeriod,
+      );
+      expect(e.isSubscribed, isTrue);
+      expect(e.yearlyPurchaseExpired, isFalse);
+    });
+
     test('permanent -> subscribed and permanent forever', () async {
       final PurchaseEntitlement e = await evaluateEntitlements(
         [_purchase(skuSubscribePermanently, '0')],

--- a/test/ui/widgets/ad_banner_container_test.dart
+++ b/test/ui/widgets/ad_banner_container_test.dart
@@ -1,0 +1,56 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:phonetowers/ui/widgets/ad_banner_container.dart';
+
+void main() {
+  Future<void> pump(WidgetTester tester, AdBannerContainer widget) {
+    return tester.pumpWidget(MaterialApp(home: Scaffold(body: widget)));
+  }
+
+  final Finder outer = find.byKey(const Key('ad-banner-outer'));
+
+  group('AdBannerContainer', () {
+    testWidgets('no ad loaded -> collapses to zero size and hides label', (tester) async {
+      await pump(tester, const AdBannerContainer(adSize: null, adChild: null));
+
+      expect(tester.getSize(outer).height, 0);
+      expect(find.text('Advertisement'), findsNothing);
+
+      final SizedBox box = tester.widget<SizedBox>(find.byType(SizedBox));
+      expect(box.width, 0);
+      expect(box.height, 0);
+    });
+
+    testWidgets('ad loaded -> sizes itself from the platform-reported adSize, not a placeholder',
+        (tester) async {
+      // Regression test for the bug where inline adaptive banner ads loaded
+      // successfully but never appeared: the widget was sized from the
+      // *requested* AdSize, which always reports height 0 for inline
+      // adaptive banners. It must instead use the real size returned by
+      // BannerAd.getPlatformAdSize() once the ad has loaded.
+      const Size loadedSize = Size(320, 50);
+      final Widget adPlaceholder = Container(key: const Key('fake-ad-view'));
+
+      await pump(tester, AdBannerContainer(adSize: loadedSize, adChild: adPlaceholder));
+
+      expect(tester.getSize(outer).height, 100);
+      expect(find.text('Advertisement'), findsOneWidget);
+
+      final SizedBox box = tester.widget<SizedBox>(find.byType(SizedBox));
+      expect(box.width, loadedSize.width);
+      expect(box.height, loadedSize.height);
+
+      // The ad content itself is actually mounted in the tree, not swapped
+      // for the empty placeholder.
+      expect(find.byKey(const Key('fake-ad-view')), findsOneWidget);
+    });
+
+    testWidgets('adSize known but adChild not yet supplied -> renders empty placeholder',
+        (tester) async {
+      await pump(tester, const AdBannerContainer(adSize: Size(320, 50), adChild: null));
+
+      final SizedBox box = tester.widget<SizedBox>(find.byType(SizedBox));
+      expect(box.child, isA<Container>());
+    });
+  });
+}


### PR DESCRIPTION
## Summary
- **Ads**: `AdsHelper` requested banners with `AdSize.getInlineAdaptiveBannerAdSize`, whose `AdSize` always reports `height == 0` by design (the real size is only known after load via `BannerAd.getPlatformAdSize()`). The banner container was sizing itself from that placeholder, so a successfully loaded ad rendered into a zero-height box and never appeared. `AdsHelper` now fetches and caches the real size after load; the sizing logic is extracted into a new `AdBannerContainer` widget so it's covered by a widget test independent of the ad platform channel.
- **Billing (iOS)**: `evaluateEntitlements` parsed `PurchaseDetails.transactionDate` with `int.tryParse` only, assuming epoch milliseconds (true for Android/StoreKit1). Older `in_app_purchase_storekit` StoreKit2 builds (≤0.4.10.x) instead reported a local-time `"yyyy-MM-dd HH:mm:ss"` string, which silently failed to parse — so a purchased `yearly_adfree` was **never** recognised as active on iOS and ads never went away. Now parses both formats.
- **Dependencies**: ran `flutter pub upgrade` within existing `pubspec.yaml` constraints (no constraint changes). Notably picks up `in_app_purchase_storekit` 0.4.11+1, which independently fixes the same StoreKit2 date-format bug upstream — the app-level fix remains as defense-in-depth.
- Docs: `AGENTS.md` gets a new "Ads and billing" section explaining both gotchas so they aren't reintroduced; `README.md` cross-references it.

## Test plan
- [x] `flutter analyze` — no new errors/warnings (795 pre-existing issues unchanged)
- [x] `flutter test` — 128/128 pass, including new `test/ui/widgets/ad_banner_container_test.dart` (3 cases) and a new StoreKit2-date-format regression case in `test/purchase_helper_test.dart`
- [ ] Manual verification on a real iOS simulator/device (not possible from this Linux dev environment — no Xcode/Simulator access)

🤖 Generated with [Claude Code](https://claude.com/claude-code)