### PR TITLE
Release 1.12.2+114: fix Polygon Precision setting having no effect on real towers

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -86,6 +86,30 @@ Tests are in `test/pathloss/` and are ported from the Java app's test suite:
 
 Run with: `flutter test test/pathloss/`
 
+## Polygon Precision (lib/helpers/polygon_helper.dart, lib/restful/get_licenceHRP.dart)
+`PolygonHelper.polygonBearingIncrement` (set from the "Polygon Precision" menu — Low/Medium/High,
+`PolygonHelper.kPolygonPrecisionLow/Medium/High`) controls the bearing step used when tracing a
+coverage ring, i.e. how many points it has.
+
+- **Two separate ring-drawing paths exist**, and both must honour this setting:
+  - `PolygonHelper.createBasicPolygon` — the circular fallback estimate, used only when a device
+    has no `deviceRegistrationIdentifier` or developer mode is on. Loops `bearing +=
+    polygonBearingIncrement` directly.
+  - `GetLicenceHRP.getLicenceHRPData` — the **primary path**, used for every real tower with
+    licence data (the vast majority of sites). This iterates over rows returned by the server
+    rather than looping over bearing directly, so it needs `GetLicenceHRP.rowStepForBearingIncrement`
+    to translate the precision setting into a row-sampling step. This function was previously
+    hardcoded to `i += 2`, silently ignoring the Polygon Precision setting entirely for real towers
+    — a real bug (the setting appeared to do nothing, since almost every tower goes through this
+    path, not the fallback). Covered by `test/restful/get_licenceHRP_test.dart`.
+- **Caching caveat**: `PolygonHelper.queryForSignalPolygon(site, refreshingPolygons,
+  cachingPolygons, ...)` — when called with `cachingPolygons == true` (e.g. the terrain-awareness
+  toggle in `option_menu.dart`) and the site/device is already cached, it reuses the previously
+  computed `PolygonContainer` points verbatim rather than recomputing geometry, so a precision
+  change won't retroactively apply until that cache entry is invalidated. The primary marker-tap
+  path (`map_common.dart` → `queryForSignalPolygon(site, false, false, ...)`) does **not** use this
+  cache, so tapping a tower after changing precision always reflects the new setting.
+
 ## Ads and billing (lib/helpers/ads_helper.dart, lib/helpers/purchase_helper.dart)
 Non-subscribed users see an inline adaptive AdMob banner at the bottom of the map; purchasing
 `yearly_adfree` or `permanent_adfree` (via `in_app_purchase`/`in_app_purchase_storekit`) removes it.

--- a/lib/restful/get_licenceHRP.dart
+++ b/lib/restful/get_licenceHRP.dart
@@ -95,7 +95,14 @@ class GetLicenceHRP {
       // Record the power output in each direction
       Map<double, double> bearingToPower = Map<double, double>();
 
-      for (int i = 0; i < totalRows; i += 2) {
+      // Server rows arrive at a fixed base resolution (2 rows sampled per point at the
+      // default/medium polygon precision). Scale the row-sampling step from the user's
+      // Polygon Precision setting relative to that default, so Low/High actually change
+      // the point density of real (non-estimated) coverage — not just the circular
+      // fallback estimate in PolygonHelper.createBasicPolygon.
+      final int rowStep = rowStepForBearingIncrement(PolygonHelper.polygonBearingIncrement);
+
+      for (int i = 0; i < totalRows; i += rowStep) {
         //Get the row
         Values? values = rawResponse!.restify!.rows![i].values;
         double start_angle = double.tryParse(values!.startAngle!.value) ?? 0;
@@ -191,6 +198,17 @@ class GetLicenceHRP {
         SiteHelper.finishSiteDownload(site);
       }
     }
+  }
+
+  /// Converts the Polygon Precision setting (a bearing step in degrees, see
+  /// [PolygonHelper.polygonBearingIncrement]) into a row-sampling step for the server's
+  /// licence HRP rows, which arrive at a fixed base resolution — 2 rows sampled per point
+  /// at the default/medium precision ([PolygonHelper.BEARING_INCREMENT]). Pure and static
+  /// so it's unit-testable without a server response.
+  static int rowStepForBearingIncrement(double bearingIncrement) {
+    final int step =
+        (2 * bearingIncrement / PolygonHelper.BEARING_INCREMENT).round();
+    return step < 1 ? 1 : step;
   }
 
   // Distance in km.

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -12,7 +12,7 @@ publish_to: 'none'
 # In iOS, build-name is used as CFBundleShortVersionString while build-number used as CFBundleVersion.
 # Read more about iOS versioning at
 # https://developer.apple.com/library/archive/documentation/General/Reference/InfoPlistKeyReference/Articles/CoreFoundationKeys.html
-version: 1.12.1+113
+version: 1.12.2+114
 
 environment:
   sdk: '>=3.9.2 <4.0.0'

--- a/test/restful/get_licenceHRP_test.dart
+++ b/test/restful/get_licenceHRP_test.dart
@@ -1,0 +1,47 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:phonetowers/helpers/polygon_helper.dart';
+import 'package:phonetowers/restful/get_licenceHRP.dart';
+
+void main() {
+  group('GetLicenceHRP.rowStepForBearingIncrement', () {
+    // Regression test: the Polygon Precision menu previously had no effect on real
+    // (non-estimated) coverage, because the server-row sampling loop hardcoded a step
+    // of 2 regardless of PolygonHelper.polygonBearingIncrement. This pins the mapping
+    // from each precision preset to its resulting row step.
+    test('medium (default) preset preserves the original hardcoded step of 2', () {
+      expect(
+        GetLicenceHRP.rowStepForBearingIncrement(PolygonHelper.kPolygonPrecisionMedium),
+        2,
+      );
+    });
+
+    test('low preset samples fewer rows (coarser, faster)', () {
+      expect(
+        GetLicenceHRP.rowStepForBearingIncrement(PolygonHelper.kPolygonPrecisionLow),
+        4,
+      );
+    });
+
+    test('high preset samples every row (finer, smoother)', () {
+      expect(
+        GetLicenceHRP.rowStepForBearingIncrement(PolygonHelper.kPolygonPrecisionHigh),
+        1,
+      );
+    });
+
+    test('never returns a step below 1, even for a very small increment', () {
+      expect(GetLicenceHRP.rowStepForBearingIncrement(0.01), 1);
+    });
+
+    test('scales monotonically with the bearing increment', () {
+      final int lowStep =
+          GetLicenceHRP.rowStepForBearingIncrement(PolygonHelper.kPolygonPrecisionLow);
+      final int mediumStep =
+          GetLicenceHRP.rowStepForBearingIncrement(PolygonHelper.kPolygonPrecisionMedium);
+      final int highStep =
+          GetLicenceHRP.rowStepForBearingIncrement(PolygonHelper.kPolygonPrecisionHigh);
+      expect(highStep, lessThan(mediumStep));
+      expect(mediumStep, lessThan(lowStep));
+    });
+  });
+}


### PR DESCRIPTION
## Summary
- The **Polygon Precision** menu (Low/Medium/High) only ever changed `PolygonHelper.createBasicPolygon`, the circular fallback estimate used when a device has no registration identifier.
- The primary ring-drawing path for real towers with licence data, `GetLicenceHRP.getLicenceHRPData`, hardcoded a server-row sampling step of `2` and never read the setting at all — so for the vast majority of towers, changing precision visibly did nothing.
- Adds `GetLicenceHRP.rowStepForBearingIncrement`, a pure function that scales the row-sampling step from `PolygonHelper.polygonBearingIncrement` relative to the existing default (exactly preserving prior behavior at Medium), and wires it into the loop.
- Documents a related, pre-existing, **not fixed here** caching caveat in `AGENTS.md`: `queryForSignalPolygon`'s `cachingPolygons=true` path reuses cached ring points verbatim, so a precision change won't retroactively apply until that cache entry is invalidated. The primary marker-tap path doesn't use that cache, so this doesn't affect the main reported symptom.

## Test plan
- [x] `flutter analyze` — no new errors/warnings
- [x] `flutter test` — 133/133 pass, including new `test/restful/get_licenceHRP_test.dart` (5 cases pinning the Low/Medium/High → row-step mapping)
- [ ] Manual verification on a real iOS simulator/device (not possible from this Linux dev environment — no Xcode/Simulator access)

🤖 Generated with [Claude Code](https://claude.com/claude-code)