### PR TITLE
Release 1.13.0+115: port Support the App prompt + match Android menu order

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -110,6 +110,42 @@ coverage ring, i.e. how many points it has.
   path (`map_common.dart` → `queryForSignalPolygon(site, false, false, ...)`) does **not** use this
   cache, so tapping a tower after changing precision always reflects the new setting.
 
+## Support the App (lib/helpers/support_prompt_helper.dart, lib/ui/widgets/support_prompt_screen.dart)
+Ported from the Java app's `SupportPromptActivity` / `MapsActivity.maybeShowSupportPrompt()`.
+
+- **`SupportPromptScreen`**: a full-screen prompt (pushed via `Navigator.push`, not a dialog) with
+  the cost-transparency message, the three donation buttons (small/medium/large, same SKUs as the
+  Donate menu), and — unless `PurchaseHelper().isSubscribed` — the two ad-free purchase buttons
+  (same SKUs as Remove Ads), plus a "Maybe later" dismiss button. All purchase taps log a
+  `support_prompt_<action>` analytics event (matching Java) before calling
+  `PurchaseHelper().initiatePurchase` and popping the route.
+- **Reachable two ways**, matching Java exactly:
+  1. Manually: the *last* item in the Donate submenu (`listDonateItem` in `option_menu.dart`,
+     `Strings.donateSupportPrompt` = "Support the App") — it is a sub-item of Donate, not a
+     separate top-level menu entry.
+  2. Automatically, about once a week: `SupportPromptHelper.decide` (pure, unit-tested in
+     `test/helpers/support_prompt_helper_test.dart`) is the ported decision logic — first-ever
+     launch just seeds a SharedPreferences timestamp without showing, then it shows once ≥7 days
+     have elapsed since it was last shown/seeded. Wired into
+     `MapBodyState.initState()` → `_maybeShowSupportPrompt()` in `map_common.dart`, deferred via
+     `addPostFrameCallback` so a `Navigator` ancestor is guaranteed to exist.
+- **Deliberately not ported**: the Java screen's "Watch an ad instead" button (a rewarded ad). This
+  app has no rewarded/interstitial ad unit configured — only banner ads (see `AdsHelper`) — and a
+  real AdMob rewarded ad unit ID would need to be created first; a test-only ad unit ID was not
+  used here to avoid shipping a fake button in production.
+
+## Top-level option menu ordering (lib/ui/widgets/option_menu.dart)
+`OptionMenuItem`'s declaration order drives the on-screen order (`OptionMenuItem.values` is mapped
+directly in `itemBuilder`). It's kept aligned with the Java app's `popup_menu.xml` order for every
+item that exists on both platforms: Reload Everything, Follow GPS, Hide Borders, Search Sites, Map
+Mode, Rotating Map, Hiding Menu, Export Data, Remove Ads, Donate, Problems Menu, Rate App, Close
+App. Two items have no Android equivalent (`lockMap`, `polygonPrecision`) and are inserted next to
+their closest thematic neighbour (`rotatingMap`, `exportData` respectively) rather than breaking
+that shared sequence. `Calculate Terrain` and `Timing Advance` are Android menu items with no iOS
+menu equivalent (Calculate Terrain is a persistent toolbar icon button in `map_common.dart`; Timing
+Advance isn't implemented on iOS at all) and are intentionally absent here — don't add them to this
+enum without also building the underlying feature.
+
 ## Ads and billing (lib/helpers/ads_helper.dart, lib/helpers/purchase_helper.dart)
 Non-subscribed users see an inline adaptive AdMob banner at the bottom of the map; purchasing
 `yearly_adfree` or `permanent_adfree` (via `in_app_purchase`/`in_app_purchase_storekit`) removes it.

--- a/README.md
+++ b/README.md
@@ -57,6 +57,7 @@ iOS. The table below lists each one and whether it can be brought to iOS.
 | Background tower service + notifications (`TowerService`) | Not available | No (iOS background limits) |
 | Coverage polygons (`PolygonHelper`, `GetLicenceHRP`) | Available | Yes (see note below) |
 | In-app purchases — Remove Ads (1 year / permanent) & Donations | Available (Google Play) | Yes (App Store) |
+| "Support the App" prompt (`SupportPromptActivity`) — donate/ad-free screen, last item of the Donate menu, also shown weekly | Available | Yes (see note below), minus the "Watch an ad instead" rewarded-ad button |
 
 ### In-app purchases
 
@@ -69,6 +70,17 @@ Both apps use the platform store for entitlements:
   on every launch.
 - **Donations** (small / medium / large): one-off consumable purchases that support development.
   They are repeatable and do **not** remove ads.
+
+**"Support the App"** (`lib/ui/widgets/support_prompt_screen.dart`) is ported from the Android
+app's `SupportPromptActivity`: a full-screen prompt with a cost-transparency message, the same
+three donation buttons, and (unless already ad-free) the two ad-free purchase buttons, plus a
+"Maybe later" dismiss button. It's reachable as the last item of the Donate menu
+(`donateSupportPrompt`) and is also shown automatically about once a week — see
+`SupportPromptHelper` (pure decision logic, unit-tested in
+`test/helpers/support_prompt_helper_test.dart`) for the exact cadence, ported from
+`MapsActivity.maybeShowSupportPrompt()`. The Android screen's "Watch an ad instead" button (a
+rewarded ad) was **not** ported — this app has no rewarded/interstitial ad unit configured (only
+banner ads), and a real AdMob rewarded ad unit would need to be created first.
 
 A banner advertisement is shown to non-subscribed users only after an ad has actually loaded; the
 "Advertisement" label is hidden until then (and whenever ads are not shown). The banner is sized

--- a/docs/USER_GUIDE.md
+++ b/docs/USER_GUIDE.md
@@ -92,6 +92,10 @@ The menu is grouped the same way as the Android app:
   bought again; the permanent option never expires.
 - **Donate** — support development with a one‑off in‑app purchase (small / medium / large).
   Donations are repeatable and do **not** remove ads (not shown on the Web build).
+  - **Support the App** — the last item in the Donate menu; opens a full‑screen "Support Aus
+    Phone Towers" prompt with the same donation options plus the ad‑free purchases (hidden if
+    you're already ad‑free), and a **Maybe later** button to dismiss. The same screen is also
+    shown automatically about once a week.
 - **Problems Menu** — a sub‑menu:
   - **Developer / Regular Mode** — show extra diagnostic overlays.
   - **User Guide** — opens this page (the top‑right menu item that previously opened the wrong

--- a/lib/helpers/support_prompt_helper.dart
+++ b/lib/helpers/support_prompt_helper.dart
@@ -1,0 +1,36 @@
+/// Pure decision logic for the weekly "Support the App" prompt, ported from the Java app's
+/// `MapsActivity.maybeShowSupportPrompt()`. Kept side-effect-free (no SharedPreferences, no
+/// BuildContext) so it's unit-testable with an injected clock — see
+/// `SupportPromptDecision` and `test/helpers/support_prompt_helper_test.dart`.
+class SupportPromptHelper {
+  static const int kWeekMillis = 7 * 24 * 60 * 60 * 1000;
+
+  /// Decides whether to show the support prompt now, given the last time it was shown (or
+  /// null if never shown / first launch) and the current time.
+  ///
+  /// Mirrors the Java behaviour exactly:
+  ///   * First-ever launch (no stored timestamp): seed the timestamp but don't show yet.
+  ///   * At least a week since it was last shown: show it, and record the new timestamp.
+  ///   * Otherwise: do nothing.
+  static SupportPromptDecision decide({
+    required int? lastShownMillis,
+    required int nowMillis,
+  }) {
+    if (lastShownMillis == null) {
+      return SupportPromptDecision(shouldShow: false, newLastShownMillis: nowMillis);
+    }
+    if (nowMillis - lastShownMillis >= kWeekMillis) {
+      return SupportPromptDecision(shouldShow: true, newLastShownMillis: nowMillis);
+    }
+    return const SupportPromptDecision(shouldShow: false, newLastShownMillis: null);
+  }
+}
+
+/// Result of [SupportPromptHelper.decide]. [newLastShownMillis] is the timestamp the caller
+/// should persist, or null if nothing needs to be written.
+class SupportPromptDecision {
+  final bool shouldShow;
+  final int? newLastShownMillis;
+
+  const SupportPromptDecision({required this.shouldShow, required this.newLastShownMillis});
+}

--- a/lib/ui/map_common.dart
+++ b/lib/ui/map_common.dart
@@ -29,6 +29,7 @@ import 'package:phonetowers/helpers/purchase_helper.dart';
 import 'package:phonetowers/helpers/screenshot_controller.dart';
 import 'package:phonetowers/helpers/search_helper.dart';
 import 'package:phonetowers/helpers/site_helper.dart';
+import 'package:phonetowers/helpers/support_prompt_helper.dart';
 import 'package:phonetowers/helpers/telco_helper.dart';
 import 'package:phonetowers/helpers/translate_frequencies.dart';
 import 'package:phonetowers/model/device_detail.dart';
@@ -41,6 +42,7 @@ import 'package:phonetowers/ui/map_platform.dart'
 import 'package:phonetowers/ui/widgets/ad_banner_container.dart';
 import 'package:phonetowers/ui/widgets/navigation_menu.dart';
 import 'package:phonetowers/ui/widgets/option_menu.dart';
+import 'package:phonetowers/ui/widgets/support_prompt_screen.dart';
 import 'package:phonetowers/utils/geo_hash.dart';
 import 'package:phonetowers/utils/hex_color.dart';
 import 'package:phonetowers/utils/shared_pref_helper.dart';
@@ -323,6 +325,7 @@ class MapBodyState extends AbstractMapBodyState with WidgetsBindingObserver {
 
     if (!kIsWeb) {
       PurchaseHelper().initStoreInfo(showSnackBar: showSnackbar);
+      WidgetsBinding.instance.addPostFrameCallback((_) => _maybeShowSupportPrompt());
     }
 
     _loadNavigationSavedState();
@@ -558,6 +561,32 @@ class MapBodyState extends AbstractMapBodyState with WidgetsBindingObserver {
   }
 
   ///********************** Helper methods *************************************
+
+  // Weekly "Support the App" prompt, ported from the Java app's
+  // MapsActivity.maybeShowSupportPrompt(). Decision logic lives in SupportPromptHelper
+  // (pure, unit-tested); this just wires it to SharedPreferences + navigation.
+  Future<void> _maybeShowSupportPrompt() async {
+    final SharedPreferences prefs = await SharedPreferences.getInstance();
+    final int? lastShown = prefs.containsKey(SharedPreferencesHelper.kSupportPromptLastShown)
+        ? SharedPreferencesHelper.getInt(
+            key: SharedPreferencesHelper.kSupportPromptLastShown, prefs: prefs)
+        : null;
+    final SupportPromptDecision decision = SupportPromptHelper.decide(
+      lastShownMillis: lastShown,
+      nowMillis: DateTime.now().millisecondsSinceEpoch,
+    );
+    if (decision.newLastShownMillis != null) {
+      await SharedPreferencesHelper.setInt(
+        key: SharedPreferencesHelper.kSupportPromptLastShown,
+        value: decision.newLastShownMillis!,
+        prefs: prefs,
+      );
+    }
+    if (decision.shouldShow && mounted) {
+      Navigator.of(context)
+          .push(MaterialPageRoute(builder: (_) => const SupportPromptScreen()));
+    }
+  }
 
   void _loadNavigationSavedState() async {
     prefs = await SharedPreferences.getInstance();

--- a/lib/ui/widgets/option_menu.dart
+++ b/lib/ui/widgets/option_menu.dart
@@ -9,6 +9,7 @@ import 'package:phonetowers/ui/map_common.dart';
 import 'package:phonetowers/helpers/purchase_helper.dart';
 import 'package:phonetowers/helpers/search_helper.dart';
 import 'package:phonetowers/helpers/site_helper.dart';
+import 'package:phonetowers/ui/widgets/support_prompt_screen.dart';
 import 'package:phonetowers/utils/app_constants.dart';
 import 'package:phonetowers/utils/shared_pref_helper.dart';
 import 'package:phonetowers/utils/strings.dart';
@@ -23,19 +24,21 @@ typedef void ShowSnackBar({
   bool isDismissible,
 });
 
-/// Top-level option-menu items, ordered to mirror the Android app's popup menu
-/// (Reload Everything, Follow GPS, Hide Borders, Search, Map Mode, Hiding Menu,
-/// Export Data, Polygon Precision, Remove Ads, Donate, Problems Menu, Rate App, Close App).
+/// Top-level option-menu items, ordered to mirror the Android app's popup menu (Reload
+/// Everything, Follow GPS, Hide Borders, Search, Map Mode, Hiding Menu, Export Data, Remove
+/// Ads, Donate, Problems Menu, Rate App, Close App). `lockMap` and `polygonPrecision` have no
+/// Android equivalent (iOS-only features) and are placed next to their closest thematic
+/// neighbour (rotatingMap, exportData) rather than breaking the shared ordering.
 /// Using an enum (rather than an index into a list) guarantees the label shown always
 /// maps to the correct behaviour — fixing the old "labels don't match the action" bug.
 enum OptionMenuItem {
   reloadEverything,
   followGPS,
-  lockMap,
-  rotatingMap,
   hideBorders,
   searchSites,
   mapMode,
+  rotatingMap,
+  lockMap,
   hidingMenu,
   exportData,
   polygonPrecision,
@@ -663,6 +666,12 @@ class _OptionsMenuState extends State<OptionsMenu> {
                     .initiatePurchase(sku: PurchaseHelper.SKU_DONATION_LARGE);
                 break;
               }
+            case 5: //Support the App
+              {
+                Navigator.of(context).push(
+                    MaterialPageRoute(builder: (_) => const SupportPromptScreen()));
+                break;
+              }
           }
           break;
         }
@@ -770,6 +779,7 @@ List<SingleRowItem> listDonateItem = <SingleRowItem>[
   SingleRowItem(
       title: Strings.donateLarge,
       isEnabled: !PurchaseHelper().isDonateLargePurchased),
+  SingleRowItem(title: Strings.donateSupportPrompt, isEnabled: true),
 ];
 
 //********************** Radio options ***************************//

--- a/lib/ui/widgets/support_prompt_screen.dart
+++ b/lib/ui/widgets/support_prompt_screen.dart
@@ -1,0 +1,104 @@
+import 'package:flutter/material.dart';
+import 'package:provider/provider.dart';
+
+import '../../helpers/analytics_helper.dart';
+import '../../helpers/purchase_helper.dart';
+import '../../utils/strings.dart';
+
+/// "Support the App" — a full-screen ask for a donation or an ad-free purchase, ported from
+/// the Java app's `SupportPromptActivity`. Reachable both from the last item of the Donate
+/// menu (`OptionMenuItem.donate` -> Donate submenu -> "Support the App") and automatically
+/// once a week (see `SupportPromptHelper` / `MapBodyState._maybeShowSupportPrompt`).
+///
+/// Note: the Java screen also offers a "Watch a short ad instead" button (a rewarded ad).
+/// That isn't ported here — this app has no rewarded/interstitial ad unit configured (only
+/// banner ads), and a real AdMob rewarded ad unit ID would need to be created first.
+class SupportPromptScreen extends StatelessWidget {
+  const SupportPromptScreen({super.key});
+
+  void _logAndPurchase(BuildContext context, String action, String sku) {
+    AnalyticsHelper().sendCustomAnalyticsEvent(
+      eventName: 'support_prompt_$action',
+      eventParameters: <String, Object>{},
+    );
+    PurchaseHelper().initiatePurchase(sku: sku);
+    Navigator.of(context).pop();
+  }
+
+  void _dismiss(BuildContext context) {
+    AnalyticsHelper().sendCustomAnalyticsEvent(
+      eventName: 'support_prompt_dismiss',
+      eventParameters: <String, Object>{},
+    );
+    Navigator.of(context).pop();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Consumer<PurchaseHelper>(
+      builder: (context, purchaseHelper, child) => Scaffold(
+        appBar: AppBar(title: Text(Strings.supportPromptTitle)),
+        body: SafeArea(
+          child: SingleChildScrollView(
+            padding: const EdgeInsets.all(24),
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.stretch,
+              children: <Widget>[
+                Text(Strings.supportPromptMessage, style: const TextStyle(fontSize: 15)),
+                const SizedBox(height: 24),
+                Text(Strings.supportPromptDonateHeader,
+                    style: const TextStyle(fontWeight: FontWeight.bold, fontSize: 16)),
+                const SizedBox(height: 8),
+                ElevatedButton(
+                  onPressed: () => _logAndPurchase(
+                      context, 'donate_small', PurchaseHelper.SKU_DONATION_SMALL),
+                  child: Text(Strings.donateSmall),
+                ),
+                const SizedBox(height: 8),
+                ElevatedButton(
+                  onPressed: () => _logAndPurchase(
+                      context, 'donate_medium', PurchaseHelper.SKU_DONATION_MEDIUM),
+                  child: Text(Strings.donateMedium),
+                ),
+                const SizedBox(height: 8),
+                ElevatedButton(
+                  onPressed: () => _logAndPurchase(
+                      context, 'donate_large', PurchaseHelper.SKU_DONATION_LARGE),
+                  child: Text(Strings.donateLarge),
+                ),
+                if (!purchaseHelper.isSubscribed) ...[
+                  const SizedBox(height: 24),
+                  Text(Strings.supportPromptAdfreeHeader,
+                      style: const TextStyle(fontWeight: FontWeight.bold, fontSize: 16)),
+                  const SizedBox(height: 8),
+                  OutlinedButton(
+                    onPressed: () => _logAndPurchase(context, 'subscribe_yearly',
+                        PurchaseHelper.SKU_SUBSCRIBE_ONE_YEAR),
+                    child: Text(Strings.remove_ads_year),
+                  ),
+                  const SizedBox(height: 8),
+                  OutlinedButton(
+                    onPressed: () => _logAndPurchase(context, 'subscribe_permanent',
+                        PurchaseHelper.SKU_SUBSCRIBE_PERMANENTLY),
+                    child: Text(Strings.remove_ads_permanent),
+                  ),
+                ],
+                const SizedBox(height: 24),
+                Text(
+                  Strings.supportPromptThanks,
+                  textAlign: TextAlign.center,
+                  style: const TextStyle(color: Colors.grey),
+                ),
+                const SizedBox(height: 16),
+                TextButton(
+                  onPressed: () => _dismiss(context),
+                  child: Text(Strings.supportPromptMaybeLater),
+                ),
+              ],
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/lib/utils/shared_pref_helper.dart
+++ b/lib/utils/shared_pref_helper.dart
@@ -49,6 +49,10 @@ class SharedPreferencesHelper {
   static final String kpolygonPrecision = 'polygonPrecision';
   static final String kfollowGPS = 'followGPS';
 
+  // Epoch millis the "Support the App" prompt was last shown/seeded — see
+  // lib/helpers/support_prompt_helper.dart.
+  static final String kSupportPromptLastShown = 'supportPromptLastShown';
+
   // Camera position persistence (for surviving backgrounding / memory reclaim).
   // Stored as a single JSON-encoded string (see camera_restore_helper.dart) so
   // the save is one atomic write instead of three independent keys that could

--- a/lib/utils/strings.dart
+++ b/lib/utils/strings.dart
@@ -111,6 +111,18 @@ class Strings {
   static String donateSmall = 'Morning Coffee (\$5.99)';
   static String donateMedium = 'Coffee and Cake (\$14.99)';
   static String donateLarge = 'Thanks For Lunch (\$29.99)';
+  static String donateSupportPrompt = 'Support the App';
+
+  // Support the App screen (see lib/ui/widgets/support_prompt_screen.dart), ported from the
+  // Java app's SupportPromptActivity.
+  static String supportPromptTitle = 'Support Aus Phone Towers';
+  static String supportPromptMessage =
+      'This app is a hobby project and costs me about \$150 per month to keep it running. '
+      'Thank you for your continued support!';
+  static String supportPromptDonateHeader = 'Make a donation';
+  static String supportPromptAdfreeHeader = 'Or remove the ads';
+  static String supportPromptThanks = 'Thank you for your continued support!';
+  static String supportPromptMaybeLater = 'Maybe later';
 
   static String developerMode = 'Developer Mode';
   static String regularMode = 'Regular Mode';

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -12,7 +12,7 @@ publish_to: 'none'
 # In iOS, build-name is used as CFBundleShortVersionString while build-number used as CFBundleVersion.
 # Read more about iOS versioning at
 # https://developer.apple.com/library/archive/documentation/General/Reference/InfoPlistKeyReference/Articles/CoreFoundationKeys.html
-version: 1.12.2+114
+version: 1.13.0+115
 
 environment:
   sdk: '>=3.9.2 <4.0.0'

--- a/test/helpers/support_prompt_helper_test.dart
+++ b/test/helpers/support_prompt_helper_test.dart
@@ -1,0 +1,40 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:phonetowers/helpers/support_prompt_helper.dart';
+
+void main() {
+  group('SupportPromptHelper.decide', () {
+    test('first-ever launch (no stored timestamp) seeds but does not show', () {
+      final SupportPromptDecision decision =
+          SupportPromptHelper.decide(lastShownMillis: null, nowMillis: 1700000000000);
+      expect(decision.shouldShow, isFalse);
+      expect(decision.newLastShownMillis, 1700000000000);
+    });
+
+    test('less than a week since last shown -> does nothing', () {
+      const int now = 1700000000000;
+      final int lastShown = now - (SupportPromptHelper.kWeekMillis - 1000); // 1s inside
+      final SupportPromptDecision decision =
+          SupportPromptHelper.decide(lastShownMillis: lastShown, nowMillis: now);
+      expect(decision.shouldShow, isFalse);
+      expect(decision.newLastShownMillis, isNull);
+    });
+
+    test('exactly a week since last shown -> shows (boundary inclusive)', () {
+      const int now = 1700000000000;
+      final int lastShown = now - SupportPromptHelper.kWeekMillis;
+      final SupportPromptDecision decision =
+          SupportPromptHelper.decide(lastShownMillis: lastShown, nowMillis: now);
+      expect(decision.shouldShow, isTrue);
+      expect(decision.newLastShownMillis, now);
+    });
+
+    test('more than a week since last shown -> shows and refreshes the timestamp', () {
+      const int now = 1700000000000;
+      final int lastShown = now - SupportPromptHelper.kWeekMillis - 1000;
+      final SupportPromptDecision decision =
+          SupportPromptHelper.decide(lastShownMillis: lastShown, nowMillis: now);
+      expect(decision.shouldShow, isTrue);
+      expect(decision.newLastShownMillis, now);
+    });
+  });
+}

--- a/test/ui/widgets/support_prompt_screen_test.dart
+++ b/test/ui/widgets/support_prompt_screen_test.dart
@@ -1,0 +1,52 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:phonetowers/helpers/purchase_helper.dart';
+import 'package:phonetowers/ui/widgets/support_prompt_screen.dart';
+import 'package:phonetowers/utils/strings.dart';
+import 'package:provider/provider.dart';
+
+void main() {
+  Future<void> pump(WidgetTester tester) {
+    return tester.pumpWidget(
+      ChangeNotifierProvider<PurchaseHelper>.value(
+        value: PurchaseHelper(),
+        child: const MaterialApp(home: SupportPromptScreen()),
+      ),
+    );
+  }
+
+  // PurchaseHelper is a singleton — reset the flag this screen reads so state doesn't
+  // leak between tests.
+  tearDown(() {
+    PurchaseHelper().isSubscribed = false;
+  });
+
+  group('SupportPromptScreen', () {
+    testWidgets('shows the title, message and all three donation options', (tester) async {
+      await pump(tester);
+      expect(find.text(Strings.supportPromptTitle), findsOneWidget);
+      expect(find.text(Strings.supportPromptMessage), findsOneWidget);
+      expect(find.text(Strings.donateSmall), findsOneWidget);
+      expect(find.text(Strings.donateMedium), findsOneWidget);
+      expect(find.text(Strings.donateLarge), findsOneWidget);
+      expect(find.text(Strings.supportPromptMaybeLater), findsOneWidget);
+    });
+
+    testWidgets('shows the ad-free options when the user is not yet ad-free', (tester) async {
+      PurchaseHelper().isSubscribed = false;
+      await pump(tester);
+      expect(find.text(Strings.supportPromptAdfreeHeader), findsOneWidget);
+      expect(find.text(Strings.remove_ads_year), findsOneWidget);
+      expect(find.text(Strings.remove_ads_permanent), findsOneWidget);
+    });
+
+    testWidgets('hides the ad-free section once the user already has ads removed',
+        (tester) async {
+      PurchaseHelper().isSubscribed = true;
+      await pump(tester);
+      expect(find.text(Strings.supportPromptAdfreeHeader), findsNothing);
+      expect(find.text(Strings.remove_ads_year), findsNothing);
+      expect(find.text(Strings.remove_ads_permanent), findsNothing);
+    });
+  });
+}


### PR DESCRIPTION
## Summary
- Ports **"Support the App"** from the Java app's `SupportPromptActivity`: a full-screen prompt (`SupportPromptScreen`) with the cost-transparency message, the three donation buttons, and (unless already ad-free) the two ad-free purchase buttons, plus a "Maybe later" dismiss button.
- Reachable exactly like Java: the **last item inside the Donate submenu** (not a separate top-level menu item), and also **shown automatically about once a week** via a ported, pure, unit-tested decision function (`SupportPromptHelper.decide`) — first-ever launch just seeds a timestamp, then it shows once ≥7 days have elapsed.
- **Not ported**: Java's "Watch an ad instead" rewarded-ad button. This app only has banner ads wired up — no rewarded/interstitial AdMob ad unit exists for it, and faking one with a test-only ID would ship a broken button in production. Can be added as a follow-up once a real rewarded ad unit is created in AdMob.
- **Reorders the top-level option menu** (`OptionMenuItem`) to match the Java app's `popup_menu.xml` for every item shared between platforms: Reload Everything, Follow GPS, Hide Borders, Search Sites, Map Mode, Rotating Map, Hiding Menu, Export Data, Remove Ads, Donate, Problems Menu, Rate App, Close App. The two iOS-only items (Lock Map, Polygon Precision, no Android equivalent) are placed next to their closest thematic neighbour rather than breaking that shared sequence.
- Docs updated in `AGENTS.md`, `README.md`, `docs/USER_GUIDE.md` per the repo's doc-sync convention.

## Test plan
- [x] `flutter analyze` — no new errors/warnings
- [x] `flutter test` — 140/140 pass, including 4 new tests for `SupportPromptHelper.decide` and 3 new widget tests for `SupportPromptScreen`
- [ ] Manual verification on a real iOS simulator/device (not possible from this Linux dev environment — no Xcode/Simulator access)

🤖 Generated with [Claude Code](https://claude.com/claude-code)