### PR TITLE
Release 1.13.1+116: pull Remove Ads/Donate/Support the App pricing live from the store

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -178,6 +178,17 @@ Non-subscribed users see an inline adaptive AdMob banner at the bottom of the ma
   `_parseTransactionDateMillis` (tries `int.tryParse` first, falls back to `DateTime.parse`) as
   defense-in-depth against older/downgraded plugin versions. Covered by
   `test/purchase_helper_test.dart`.
+- **Live pricing, not hardcoded**: menu/screen labels (Remove Ads, Donate, Support the App) show
+  the store's own localized price string (`ProductDetails.price`, from `_getProducts()`'s
+  `queryProductDetails` call), not a hardcoded `$X.XX` literal — prices vary by storefront/locale
+  and can change without an app update. `PriceLabelHelper` (pure, `lib/helpers/price_label_helper.dart`,
+  tested in `test/helpers/price_label_helper_test.dart`) builds `"Name ($price)"` from a product
+  list; `PurchaseHelper.priceFor` / `priceLabel` are thin instance wrappers over it. The hardcoded
+  `Strings.donateSmall` / `remove_ads_year` etc. strings are kept only as the **fallback** shown
+  before `_getProducts()` resolves (or if it fails) — don't remove them. `_getProducts()` calls
+  `notifyListeners()` once products load so already-open `Consumer<PurchaseHelper>` UI (e.g.
+  `SupportPromptScreen`) picks up live pricing without needing an unrelated purchase event to
+  trigger a rebuild first.
 
 ## Documentation must be kept in sync
 Whenever you add, change, or remove a user-facing feature, command, or behaviour in this

--- a/README.md
+++ b/README.md
@@ -71,6 +71,11 @@ Both apps use the platform store for entitlements:
 - **Donations** (small / medium / large): one-off consumable purchases that support development.
   They are repeatable and do **not** remove ads.
 
+Menu/screen labels for all five products show the store's own **live, localized price** (fetched
+via `queryProductDetails`), not a hardcoded `$X.XX` — see `PriceLabelHelper` in the "Ads and
+billing" section of `AGENTS.md`. A hardcoded price is shown only as a fallback until pricing has
+loaded (or if the store query fails).
+
 **"Support the App"** (`lib/ui/widgets/support_prompt_screen.dart`) is ported from the Android
 app's `SupportPromptActivity`: a full-screen prompt with a cost-transparency message, the same
 three donation buttons, and (unless already ad-free) the two ad-free purchase buttons, plus a

--- a/lib/helpers/price_label_helper.dart
+++ b/lib/helpers/price_label_helper.dart
@@ -1,0 +1,34 @@
+import 'package:in_app_purchase/in_app_purchase.dart';
+
+/// Builds menu/screen labels from live App Store / Play Store pricing instead of a hardcoded
+/// price, e.g. "Morning Coffee ($5.99)" using the store's own localized price string (which
+/// already carries the correct currency symbol/formatting for the user's storefront) rather
+/// than an assumed-USD/AUD literal baked into the app.
+///
+/// Kept pure (no StoreKit, no PurchaseHelper singleton) so it's unit-testable with an injected
+/// product list — see PurchaseHelper.priceFor / priceLabel for the singleton-backed wrapper
+/// used by the UI, and test/helpers/price_label_helper_test.dart.
+class PriceLabelHelper {
+  /// Finds the store's localized price string for [sku] within [products], or null if the
+  /// product isn't present (store query still in flight, failed, or an unknown SKU).
+  static String? findPrice(List<ProductDetails?> products, String sku) {
+    for (final ProductDetails? product in products) {
+      if (product?.id == sku) return product?.price;
+    }
+    return null;
+  }
+
+  /// Combines [name] with the live price for [sku] within [products] if known — e.g.
+  /// `buildLabel(products: products, sku: sku, name: 'Morning Coffee', fallback: fallback)` ->
+  /// `"Morning Coffee ($5.99)"`. Falls back to [fallback] (typically a hardcoded "Name ($X.XX)"
+  /// string) when pricing hasn't loaded yet, so the menu never shows a broken/blank price.
+  static String buildLabel({
+    required List<ProductDetails?> products,
+    required String sku,
+    required String name,
+    required String fallback,
+  }) {
+    final String? price = findPrice(products, sku);
+    return price != null ? '$name ($price)' : fallback;
+  }
+}

--- a/lib/helpers/purchase_helper.dart
+++ b/lib/helpers/purchase_helper.dart
@@ -10,6 +10,7 @@ import 'package:phonetowers/billing/consumable_store.dart';
 
 import 'analytics_helper.dart';
 import 'entitlement_evaluator.dart';
+import 'price_label_helper.dart';
 
 typedef void ShowSnackBar({
   required String message,
@@ -145,6 +146,22 @@ class PurchaseHelper with ChangeNotifier {
     await _inAppPurchase.restorePurchases();
   }
 
+  /// Test-only seam for injecting fake product details without a real store connection — see
+  /// test/ui/widgets/support_prompt_screen_test.dart.
+  @visibleForTesting
+  set debugProducts(List<ProductDetails?> products) => _products = products;
+
+  /// The store's localized price string for [sku] (e.g. "$5.99", "A$5.99", "€5.49" — already
+  /// formatted for the user's storefront/locale), or null if product details haven't loaded
+  /// yet (the store query is still in flight, failed, or [sku] is unknown).
+  String? priceFor(String sku) => PriceLabelHelper.findPrice(_products, sku);
+
+  /// Builds a menu/screen label combining [name] with the live store price for [sku], falling
+  /// back to [fallback] (typically a hardcoded "Name ($X.XX)" string) while pricing hasn't
+  /// loaded yet, so menus never show a broken/blank price.
+  String priceLabel({required String sku, required String name, required String fallback}) =>
+      PriceLabelHelper.buildLabel(products: _products, sku: sku, name: name, fallback: fallback);
+
   /// Get all products available for sale
   Future<void> _getProducts() async {
     if (Platform.isIOS) {
@@ -253,6 +270,10 @@ class PurchaseHelper with ChangeNotifier {
     String error = "In-App Billing is completed!";
     //showSnackBar(message: error);
     logger.i("PurchaseHelper: " + error);
+
+    // Let any already-open UI (e.g. SupportPromptScreen) pick up live store pricing —
+    // see priceFor/priceLabel — without needing an unrelated purchase event to fire.
+    notifyListeners();
   }
 
   @override

--- a/lib/ui/widgets/option_menu.dart
+++ b/lib/ui/widgets/option_menu.dart
@@ -224,14 +224,20 @@ class _OptionsMenuState extends State<OptionsMenu> {
                 listRemoveAdsItem.elementAt(2)
                   ..title =
                       PurchaseHelper().timeToExpireYearlySubscription.isEmpty
-                          ? Strings.remove_ads_year
+                          ? PurchaseHelper().priceLabel(
+                              sku: PurchaseHelper.SKU_SUBSCRIBE_ONE_YEAR,
+                              name: Strings.remove_ads_year_name,
+                              fallback: Strings.remove_ads_year)
                           : PurchaseHelper().timeToExpireYearlySubscription
                   ..isEnabled =
                       PurchaseHelper().timeToExpireYearlySubscription.isEmpty;
                 listRemoveAdsItem.elementAt(3)
                   ..title = PurchaseHelper().isSubscribedPermanently
                       ? Strings.subscribed_permanently
-                      : Strings.remove_ads_permanent
+                      : PurchaseHelper().priceLabel(
+                          sku: PurchaseHelper.SKU_SUBSCRIBE_PERMANENTLY,
+                          name: Strings.remove_ads_permanent_name,
+                          fallback: Strings.remove_ads_permanent)
                   ..isEnabled = !PurchaseHelper().isSubscribedPermanently;
                 listRemoveAdsItem.elementAt(4)
                   ..isEnabled = !PurchaseHelper().isSubscribed;
@@ -241,10 +247,22 @@ class _OptionsMenuState extends State<OptionsMenu> {
             case OptionMenuItem.donate:
               {
                 listDonateItem.elementAt(2)
+                  ..title = PurchaseHelper().priceLabel(
+                      sku: PurchaseHelper.SKU_DONATION_SMALL,
+                      name: Strings.donateSmallName,
+                      fallback: Strings.donateSmall)
                   ..isEnabled = !purchaseHelper.isDonateSmallPurchased;
                 listDonateItem.elementAt(3)
+                  ..title = PurchaseHelper().priceLabel(
+                      sku: PurchaseHelper.SKU_DONATION_MEDIUM,
+                      name: Strings.donateMediumName,
+                      fallback: Strings.donateMedium)
                   ..isEnabled = !purchaseHelper.isDonateMediumPurchased;
                 listDonateItem.elementAt(4)
+                  ..title = PurchaseHelper().priceLabel(
+                      sku: PurchaseHelper.SKU_DONATION_LARGE,
+                      name: Strings.donateLargeName,
+                      fallback: Strings.donateLarge)
                   ..isEnabled = !purchaseHelper.isDonateLargePurchased;
                 showSingleRowOptionMenu(listDonateItem, kDonate);
                 break;
@@ -754,13 +772,19 @@ List<SingleRowItem> listRemoveAdsItem = <SingleRowItem>[
       isEnabled: false),
   SingleRowItem(
       title: PurchaseHelper().timeToExpireYearlySubscription.isEmpty
-          ? Strings.remove_ads_year
+          ? PurchaseHelper().priceLabel(
+              sku: PurchaseHelper.SKU_SUBSCRIBE_ONE_YEAR,
+              name: Strings.remove_ads_year_name,
+              fallback: Strings.remove_ads_year)
           : PurchaseHelper().timeToExpireYearlySubscription,
       isEnabled: PurchaseHelper().timeToExpireYearlySubscription.isEmpty),
   SingleRowItem(
       title: PurchaseHelper().isSubscribedPermanently
           ? Strings.subscribed_permanently
-          : Strings.remove_ads_permanent,
+          : PurchaseHelper().priceLabel(
+              sku: PurchaseHelper.SKU_SUBSCRIBE_PERMANENTLY,
+              name: Strings.remove_ads_permanent_name,
+              fallback: Strings.remove_ads_permanent),
       isEnabled: !PurchaseHelper().isSubscribedPermanently),
   SingleRowItem(
       title: Strings.restore_purchases,
@@ -771,13 +795,22 @@ List<SingleRowItem> listDonateItem = <SingleRowItem>[
   SingleRowItem(isTitle: true, title: Strings.donate, isEnabled: true),
   SingleRowItem(title: Strings.donatePrevious, isEnabled: false),
   SingleRowItem(
-      title: Strings.donateSmall,
+      title: PurchaseHelper().priceLabel(
+          sku: PurchaseHelper.SKU_DONATION_SMALL,
+          name: Strings.donateSmallName,
+          fallback: Strings.donateSmall),
       isEnabled: !PurchaseHelper().isDonateSmallPurchased),
   SingleRowItem(
-      title: Strings.donateMedium,
+      title: PurchaseHelper().priceLabel(
+          sku: PurchaseHelper.SKU_DONATION_MEDIUM,
+          name: Strings.donateMediumName,
+          fallback: Strings.donateMedium),
       isEnabled: !PurchaseHelper().isDonateMediumPurchased),
   SingleRowItem(
-      title: Strings.donateLarge,
+      title: PurchaseHelper().priceLabel(
+          sku: PurchaseHelper.SKU_DONATION_LARGE,
+          name: Strings.donateLargeName,
+          fallback: Strings.donateLarge),
       isEnabled: !PurchaseHelper().isDonateLargePurchased),
   SingleRowItem(title: Strings.donateSupportPrompt, isEnabled: true),
 ];

--- a/lib/ui/widgets/support_prompt_screen.dart
+++ b/lib/ui/widgets/support_prompt_screen.dart
@@ -52,19 +52,28 @@ class SupportPromptScreen extends StatelessWidget {
                 ElevatedButton(
                   onPressed: () => _logAndPurchase(
                       context, 'donate_small', PurchaseHelper.SKU_DONATION_SMALL),
-                  child: Text(Strings.donateSmall),
+                  child: Text(purchaseHelper.priceLabel(
+                      sku: PurchaseHelper.SKU_DONATION_SMALL,
+                      name: Strings.donateSmallName,
+                      fallback: Strings.donateSmall)),
                 ),
                 const SizedBox(height: 8),
                 ElevatedButton(
                   onPressed: () => _logAndPurchase(
                       context, 'donate_medium', PurchaseHelper.SKU_DONATION_MEDIUM),
-                  child: Text(Strings.donateMedium),
+                  child: Text(purchaseHelper.priceLabel(
+                      sku: PurchaseHelper.SKU_DONATION_MEDIUM,
+                      name: Strings.donateMediumName,
+                      fallback: Strings.donateMedium)),
                 ),
                 const SizedBox(height: 8),
                 ElevatedButton(
                   onPressed: () => _logAndPurchase(
                       context, 'donate_large', PurchaseHelper.SKU_DONATION_LARGE),
-                  child: Text(Strings.donateLarge),
+                  child: Text(purchaseHelper.priceLabel(
+                      sku: PurchaseHelper.SKU_DONATION_LARGE,
+                      name: Strings.donateLargeName,
+                      fallback: Strings.donateLarge)),
                 ),
                 if (!purchaseHelper.isSubscribed) ...[
                   const SizedBox(height: 24),
@@ -74,13 +83,19 @@ class SupportPromptScreen extends StatelessWidget {
                   OutlinedButton(
                     onPressed: () => _logAndPurchase(context, 'subscribe_yearly',
                         PurchaseHelper.SKU_SUBSCRIBE_ONE_YEAR),
-                    child: Text(Strings.remove_ads_year),
+                    child: Text(purchaseHelper.priceLabel(
+                        sku: PurchaseHelper.SKU_SUBSCRIBE_ONE_YEAR,
+                        name: Strings.remove_ads_year_name,
+                        fallback: Strings.remove_ads_year)),
                   ),
                   const SizedBox(height: 8),
                   OutlinedButton(
                     onPressed: () => _logAndPurchase(context, 'subscribe_permanent',
                         PurchaseHelper.SKU_SUBSCRIBE_PERMANENTLY),
-                    child: Text(Strings.remove_ads_permanent),
+                    child: Text(purchaseHelper.priceLabel(
+                        sku: PurchaseHelper.SKU_SUBSCRIBE_PERMANENTLY,
+                        name: Strings.remove_ads_permanent_name,
+                        fallback: Strings.remove_ads_permanent)),
                   ),
                 ],
                 const SizedBox(height: 24),

--- a/lib/utils/strings.dart
+++ b/lib/utils/strings.dart
@@ -101,6 +101,12 @@ class Strings {
   static String remove_ads = 'Remove Ads';
   static String remove_ads_subscribe_previous =
       'You are subscribed! Thanking you.';
+  // Product names, with no price baked in — the live price is pulled from the store via
+  // PurchaseHelper.priceLabel (see PriceLabelHelper) and appended at display time.
+  static String remove_ads_year_name = 'One Year Ad Free';
+  static String remove_ads_permanent_name = 'Permanent Ad Free';
+  // Fallback labels (with a hardcoded price) used only until the store's product details have
+  // loaded — see PurchaseHelper.priceLabel.
   static String remove_ads_year = 'One Year Ad Free (\$9.99)';
   static String remove_ads_permanent = 'Permanent Ad Free (\$24.99)';
   static String subscribed_permanently = 'Permanently subscribed.';
@@ -108,6 +114,12 @@ class Strings {
 
   static String donate = 'Donate';
   static String donatePrevious = 'Thanks for your previous donation!';
+  // Product names, with no price baked in (see remove_ads_year_name above).
+  static String donateSmallName = 'Morning Coffee';
+  static String donateMediumName = 'Coffee and Cake';
+  static String donateLargeName = 'Thanks For Lunch';
+  // Fallback labels (with a hardcoded price) used only until the store's product details have
+  // loaded — see PurchaseHelper.priceLabel.
   static String donateSmall = 'Morning Coffee (\$5.99)';
   static String donateMedium = 'Coffee and Cake (\$14.99)';
   static String donateLarge = 'Thanks For Lunch (\$29.99)';

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -12,7 +12,7 @@ publish_to: 'none'
 # In iOS, build-name is used as CFBundleShortVersionString while build-number used as CFBundleVersion.
 # Read more about iOS versioning at
 # https://developer.apple.com/library/archive/documentation/General/Reference/InfoPlistKeyReference/Articles/CoreFoundationKeys.html
-version: 1.13.0+115
+version: 1.13.1+116
 
 environment:
   sdk: '>=3.9.2 <4.0.0'

--- a/test/helpers/price_label_helper_test.dart
+++ b/test/helpers/price_label_helper_test.dart
@@ -1,0 +1,67 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:in_app_purchase/in_app_purchase.dart';
+import 'package:phonetowers/helpers/price_label_helper.dart';
+
+ProductDetails _product(String id, String price) {
+  return ProductDetails(
+    id: id,
+    title: id,
+    description: '',
+    price: price,
+    rawPrice: 0,
+    currencyCode: 'AUD',
+  );
+}
+
+void main() {
+  group('PriceLabelHelper.findPrice', () {
+    test('returns the price for a matching product', () {
+      final price = PriceLabelHelper.findPrice([_product('sku_a', '\$5.99')], 'sku_a');
+      expect(price, '\$5.99');
+    });
+
+    test('returns null when the product list is empty (store query not loaded yet)', () {
+      expect(PriceLabelHelper.findPrice([], 'sku_a'), isNull);
+    });
+
+    test('returns null for an unknown sku not present in the product list', () {
+      final price = PriceLabelHelper.findPrice([_product('sku_a', '\$5.99')], 'sku_b');
+      expect(price, isNull);
+    });
+
+    test('ignores null entries in the product list', () {
+      final price =
+          PriceLabelHelper.findPrice([null, _product('sku_a', '\$5.99'), null], 'sku_a');
+      expect(price, '\$5.99');
+    });
+
+    test('picks the store-localized price, not a hardcoded currency assumption', () {
+      // e.g. a non-US/AU storefront could return "€5.49" or "£4.99" — findPrice must pass
+      // the store's own formatted string through verbatim.
+      final price = PriceLabelHelper.findPrice([_product('sku_a', '€5.49')], 'sku_a');
+      expect(price, '€5.49');
+    });
+  });
+
+  group('PriceLabelHelper.buildLabel', () {
+    test('uses the live store price when the product has loaded', () {
+      final label = PriceLabelHelper.buildLabel(
+        products: [_product('sku_a', '\$5.99')],
+        sku: 'sku_a',
+        name: 'Morning Coffee',
+        fallback: 'Morning Coffee (\$5.99 - fallback)',
+      );
+      expect(label, 'Morning Coffee (\$5.99)');
+    });
+
+    test('falls back to the provided text when pricing has not loaded yet', () {
+      final label = PriceLabelHelper.buildLabel(
+        products: [],
+        sku: 'sku_a',
+        name: 'Morning Coffee',
+        fallback: 'Morning Coffee (\$5.99 - fallback)',
+      );
+      expect(label, 'Morning Coffee (\$5.99 - fallback)');
+    });
+  });
+}

--- a/test/ui/widgets/support_prompt_screen_test.dart
+++ b/test/ui/widgets/support_prompt_screen_test.dart
@@ -1,9 +1,21 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:in_app_purchase/in_app_purchase.dart';
 import 'package:phonetowers/helpers/purchase_helper.dart';
 import 'package:phonetowers/ui/widgets/support_prompt_screen.dart';
 import 'package:phonetowers/utils/strings.dart';
 import 'package:provider/provider.dart';
+
+ProductDetails _product(String id, String price) {
+  return ProductDetails(
+    id: id,
+    title: id,
+    description: '',
+    price: price,
+    rawPrice: 0,
+    currencyCode: 'AUD',
+  );
+}
 
 void main() {
   Future<void> pump(WidgetTester tester) {
@@ -15,10 +27,11 @@ void main() {
     );
   }
 
-  // PurchaseHelper is a singleton — reset the flag this screen reads so state doesn't
-  // leak between tests.
+  // PurchaseHelper is a singleton — reset the state this screen reads so it doesn't leak
+  // between tests.
   tearDown(() {
     PurchaseHelper().isSubscribed = false;
+    PurchaseHelper().debugProducts = [];
   });
 
   group('SupportPromptScreen', () {
@@ -47,6 +60,21 @@ void main() {
       expect(find.text(Strings.supportPromptAdfreeHeader), findsNothing);
       expect(find.text(Strings.remove_ads_year), findsNothing);
       expect(find.text(Strings.remove_ads_permanent), findsNothing);
+    });
+
+    testWidgets('shows live store pricing once product details have loaded, not the hardcoded fallback',
+        (tester) async {
+      PurchaseHelper().debugProducts = [
+        _product(PurchaseHelper.SKU_DONATION_SMALL, '\$1.23'),
+        _product(PurchaseHelper.SKU_SUBSCRIBE_ONE_YEAR, '\$4.56'),
+      ];
+      await pump(tester);
+      expect(find.text('${Strings.donateSmallName} (\$1.23)'), findsOneWidget);
+      expect(find.text(Strings.donateSmall), findsNothing);
+      expect(find.text('${Strings.remove_ads_year_name} (\$4.56)'), findsOneWidget);
+      expect(find.text(Strings.remove_ads_year), findsNothing);
+      // Products with no matching entry in the store response still fall back.
+      expect(find.text(Strings.donateMedium), findsOneWidget);
     });
   });
 }


### PR DESCRIPTION
## Summary
- Remove Ads, Donate and Support the App menu/screen labels previously showed a hardcoded `$X.XX` price. Store prices vary by storefront/locale and can change without an app update, so these now use the store's own localized `ProductDetails.price` (fetched via `queryProductDetails`) instead.
- New `PriceLabelHelper` (pure, unit-tested) builds `"Name ($price)"` from a product list; `PurchaseHelper.priceFor` / `priceLabel` are thin instance wrappers over it.
- The old hardcoded strings (`Strings.donateSmall` etc.) are kept as the **fallback** shown only until the store query resolves (or if it fails) — not deleted.
- `_getProducts()` now calls `notifyListeners()` once products load, so already-open `Consumer<PurchaseHelper>` UI (e.g. the Support Prompt screen) picks up live pricing without waiting for an unrelated purchase event to trigger a rebuild.
- Docs updated in `AGENTS.md` and `README.md`.

## Test plan
- [x] `flutter analyze` — no new errors/warnings
- [x] `flutter test` — 148/148 pass, including 7 new tests for `PriceLabelHelper` and a new widget test proving the Support Prompt screen shows live pricing (via a `@visibleForTesting` seam) instead of the hardcoded fallback
- [ ] Manual verification on a real iOS simulator/device (not possible from this Linux dev environment — no Xcode/Simulator access)

🤖 Generated with [Claude Code](https://claude.com/claude-code)